### PR TITLE
CANN: CONV_TRANSPOSE_1D

### DIFF
--- a/ggml/src/ggml-cann/aclnn_ops.h
+++ b/ggml/src/ggml-cann/aclnn_ops.h
@@ -46,6 +46,7 @@
 #include <aclnnop/aclnn_cos.h>
 #include <aclnnop/aclnn_log.h>
 #include <aclnnop/aclnn_sign.h>
+#include <aclnnop/aclnn_slice.h>
 #include "acl_tensor.h"
 #include "common.h"
 


### PR DESCRIPTION
# 描述 (Description)


本 PR 在 ggml 的 CANN 后端中实现 CONV_TRANSPOSE_1D 算子对kernel_size $\ge$ 255 的支持。现有的 CONV_TRANSPOSE_1D 算子通过直接调用 Convolution 的方式实现，对于 kernel_size $\ge$ 255 的输入会报错形状错误。

变更摘要：

在 ggml/src/ggml-cann/aclnn_ops.h 中增加头文件aclnnop/aclnn_slice.h 以支持slice操作。

在 ggml/src/ggml-cann/aclnn_ops.cpp 中增加函数实现。大致思路如下：

- 将大kernel切片为多个 $\le$ 255 的小kernel
- 将每个小kernel分别和输入进行CONV_TRANSPOSE1D得到各部分结果
- 计算各部分结果在最终结果中的起始和终止位置并pad到与输出相同的长度
- 对各部分结果求和得到最终结果

在 ggml/src/ggml-cann/ggml-cann.cpp 中，移除判断条件:

```c++

case GGML_OP_CONV_TRANSPOSE_1D:
    // TODO: ((weightL - 1) * dilationW - padLeft)=1336 should not be larger than 255.
    return (op->src[0]->ne[0] - 1) <= 255;
```



# 测试 (Testing)

测试步骤：

- 执行编译：

```bash
cmake -B build -DGGML_CANN=on -DCMAKE_BUILD_TYPE=release
cmake --build build --config release -j
```

- 运行测试:

```bash
./bin/test-backend-ops test -b CANN0 -o CONV_TRANSPOSE1D
```

- 测试结果:

<img width="1159" height="345" alt="image" src="https://github.com/user-attachments/assets/8c4905a7-4b85-4b2a-8034-2365f74daf82" />


# 备注 (Notes)

无