### PR TITLE
CANN: Add support for OUT_PROD operator

### DIFF
--- a/ggml/src/ggml-cann/aclnn_ops.cpp
+++ b/ggml/src/ggml-cann/aclnn_ops.cpp
@@ -22,54 +22,58 @@
 
 #include "aclnn_ops.h"
 
+#include "ggml-backend.h"
+#include "ggml-cpu.h"
+#include "ggml-impl.h"
+#include "ggml.h"
+
+#include <aclnnop/aclnn_add.h>
 #include <aclnnop/aclnn_addcdiv.h>
+#include <aclnnop/aclnn_argmax.h>
 #include <aclnnop/aclnn_avgpool2d.h>
 #include <aclnnop/aclnn_batch_matmul.h>
 #include <aclnnop/aclnn_cast.h>
 #include <aclnnop/aclnn_constant_pad_nd.h>
+#include <aclnnop/aclnn_convolution.h>
 #include <aclnnop/aclnn_copy.h>
 #include <aclnnop/aclnn_div.h>
+#include <aclnnop/aclnn_elu.h>
 #include <aclnnop/aclnn_embedding.h>
+#include <aclnnop/aclnn_eq_tensor.h>
 #include <aclnnop/aclnn_exp.h>
 #include <aclnnop/aclnn_fill_scalar.h>
+#include <aclnnop/aclnn_fused_infer_attention_score_v2.h>
 #include <aclnnop/aclnn_group_norm.h>
+#include <aclnnop/aclnn_grouped_matmul_v3.h>
+#include <aclnnop/aclnn_gt_scalar.h>
+#include <aclnnop/aclnn_im2col.h>
+#include <aclnnop/aclnn_index_copy.h>
 #include <aclnnop/aclnn_index_fill_tensor.h>
+#include <aclnnop/aclnn_index_select.h>
 #include <aclnnop/aclnn_layer_norm.h>
+#include <aclnnop/aclnn_log.h>
 #include <aclnnop/aclnn_matmul.h>
 #include <aclnnop/aclnn_max_pool.h>
+#include <aclnnop/aclnn_mean.h>
 #include <aclnnop/aclnn_mm.h>
+#include <aclnnop/aclnn_mul.h>
 #include <aclnnop/aclnn_permute.h>
+#include <aclnnop/aclnn_pow.h>
 #include <aclnnop/aclnn_pow_tensor_tensor.h>
 #include <aclnnop/aclnn_reduce_sum.h>
+#include <aclnnop/aclnn_reflection_pad1d.h>
 #include <aclnnop/aclnn_repeat.h>
 #include <aclnnop/aclnn_repeat_interleave.h>
+#include <aclnnop/aclnn_rms_norm.h>
 #include <aclnnop/aclnn_roll.h>
 #include <aclnnop/aclnn_softmax.h>
+#include <aclnnop/aclnn_sub.h>
+#include <aclnnop/aclnn_sum.h>
 #include <aclnnop/aclnn_tril.h>
 #include <aclnnop/aclnn_triu.h>
 #include <aclnnop/aclnn_upsample_nearest_2d.h>
 #include <aclnnop/aclnn_weight_quant_batch_matmul_v2.h>
-#include <aclnnop/aclnn_argmax.h>
-#include <aclnnop/aclnn_sum.h>
-#include <aclnnop/aclnn_rms_norm.h>
-#include <aclnnop/aclnn_im2col.h>
-#include <aclnnop/aclnn_add.h>
-#include <aclnnop/aclnn_sub.h>
-#include <aclnnop/aclnn_mul.h>
-#include <aclnnop/aclnn_div.h>
-#include <aclnnop/aclnn_convolution.h>
-#include <aclnnop/aclnn_elu.h>
-#include <aclnnop/aclnn_log.h>
-#include <aclnnop/aclnn_mean.h>
-#include <aclnnop/aclnn_reflection_pad1d.h>
-#include <aclnnop/aclnn_eq_tensor.h>
-#include <aclnnop/aclnn_gt_scalar.h>
-#include <aclnnop/aclnn_pow.h>
-#include <aclnnop/aclnn_grouped_matmul_v3.h>
-#include <aclnnop/aclnn_fused_infer_attention_score_v2.h>
 #include <aclnnop/aclnn_zero.h>
-#include <aclnnop/aclnn_index_copy.h>
-#include <aclnnop/aclnn_index_select.h>
 #include <float.h>
 
 #include <cmath>
@@ -77,16 +81,16 @@
 #include <exception>
 #include <vector>
 
-#include "ggml-impl.h"
-#include "ggml.h"
-
 #define GGML_COMMON_DECL_C
 
 #include "../ggml-common.h"
 
-
-void bcast_shape(ggml_tensor * src0, ggml_tensor * src1, ggml_tensor * dst, aclTensor ** acl_src0,
-                 aclTensor ** acl_src1, aclTensor ** acl_dst) {
+void bcast_shape(ggml_tensor * src0,
+                 ggml_tensor * src1,
+                 ggml_tensor * dst,
+                 aclTensor **  acl_src0,
+                 aclTensor **  acl_src1,
+                 aclTensor **  acl_dst) {
     GGML_ASSERT(ggml_are_same_shape(src0, dst) && ggml_can_repeat(src1, src0));
     // Need bcast
     if (!ggml_are_same_shape(src0, src1) && ggml_cann_need_bcast(src0, src1)) {
@@ -101,40 +105,40 @@ void bcast_shape(ggml_tensor * src0, ggml_tensor * src1, ggml_tensor * dst, aclT
     }
 }
 
-void ggml_cann_op_unary(
-    std::function<void(ggml_backend_cann_context&, aclTensor*, aclTensor*)> unary_op,
-    ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_op_unary(std::function<void(ggml_backend_cann_context &, aclTensor *, aclTensor *)> unary_op,
+                        ggml_backend_cann_context &                                                ctx,
+                        ggml_tensor *                                                              dst) {
+    ggml_tensor * src = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     unary_op(ctx, acl_src, acl_dst);
     ggml_cann_release_resources(ctx, acl_src, acl_dst);
 }
 
-void ggml_cann_op_unary_gated(
-    std::function<void(ggml_backend_cann_context&, aclTensor*, aclTensor*)> unary_op,
-    ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];
-    ggml_tensor* src1 = dst->src[1];
+void ggml_cann_op_unary_gated(std::function<void(ggml_backend_cann_context &, aclTensor *, aclTensor *)> unary_op,
+                              ggml_backend_cann_context &                                                ctx,
+                              ggml_tensor *                                                              dst) {
+    ggml_tensor * src0 = dst->src[0];
+    ggml_tensor * src1 = dst->src[1];
 
     GGML_ASSERT(ggml_is_contiguous_1(src0));
     GGML_ASSERT(ggml_is_contiguous_1(dst));
     const int32_t swapped = ggml_get_op_params_i32(dst, 1);
 
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
-    aclTensor *acl_src0 = nullptr, *acl_src1 = nullptr;
-    if(src1) {
+    aclTensor * acl_dst  = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src0 = nullptr, *acl_src1 = nullptr;
+    if (src1) {
         GGML_ASSERT(ggml_is_contiguous_1(src1));
         GGML_ASSERT(src0->type == src1->type);
 
         acl_src0 = ggml_cann_create_tensor(src0);
         acl_src1 = ggml_cann_create_tensor(src1);
     } else {
-        int64_t ne[] = {src0->ne[0] / 2, src0->ne[1], src0->ne[2], src0->ne[3]};
-        size_t nb[] = {src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3]};
-        acl_src0 = ggml_cann_create_tensor(src0, ne, nb, GGML_MAX_DIMS, ACL_FORMAT_ND, 0);
+        int64_t ne[] = { src0->ne[0] / 2, src0->ne[1], src0->ne[2], src0->ne[3] };
+        size_t  nb[] = { src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3] };
+        acl_src0     = ggml_cann_create_tensor(src0, ne, nb, GGML_MAX_DIMS, ACL_FORMAT_ND, 0);
         acl_src1 = ggml_cann_create_tensor(src0, ne, nb, GGML_MAX_DIMS, ACL_FORMAT_ND, ne[0] * ggml_element_size(src0));
         if (swapped) {
             std::swap(acl_src0, acl_src1);
@@ -145,8 +149,9 @@ void ggml_cann_op_unary_gated(
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceMul, acl_dst, acl_src1);
 
     ggml_cann_release_resources(ctx, acl_src0, acl_dst);
-    if(src1)
+    if (src1) {
         ggml_cann_release_resources(ctx, acl_src1);
+    }
 }
 
 /**
@@ -159,10 +164,12 @@ void ggml_cann_op_unary_gated(
  * @param repeat_array The array specifying the number of repetitions along each
  * dimension.
  */
-static void aclnn_repeat(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                         aclTensor* acl_dst, int64_t* repeat_array) {
+static void aclnn_repeat(ggml_backend_cann_context & ctx,
+                         aclTensor *                 acl_src,
+                         aclTensor *                 acl_dst,
+                         int64_t *                   repeat_array) {
     // repeat tensor along each dim with repeat_array
-    aclIntArray* repeats = aclCreateIntArray(repeat_array, GGML_MAX_DIMS);
+    aclIntArray * repeats = aclCreateIntArray(repeat_array, GGML_MAX_DIMS);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, Repeat, acl_src, repeats, acl_dst);
     ggml_cann_release_resources(ctx, repeats);
@@ -181,61 +188,64 @@ static void aclnn_repeat(ggml_backend_cann_context& ctx, aclTensor* acl_src,
  * @param cast_data_type The target data type to which the source tensor will be
  * casted.
  */
-static void aclnn_cast(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-    aclTensor* acl_dst, aclDataType cast_data_type) {
+static void aclnn_cast(ggml_backend_cann_context & ctx,
+                       aclTensor *                 acl_src,
+                       aclTensor *                 acl_dst,
+                       aclDataType                 cast_data_type) {
     GGML_CANN_CALL_ACLNN_OP(ctx, Cast, acl_src, cast_data_type, acl_dst);
 }
 
-void ggml_cann_repeat(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_repeat(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
     GGML_ASSERT(ggml_can_repeat(src, dst));
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
-    int64_t repeatsArray[] = {dst->ne[3] / src->ne[3], dst->ne[2] / src->ne[2],
-                              dst->ne[1] / src->ne[1], dst->ne[0] / src->ne[0]};
+    int64_t repeatsArray[] = {
+        dst->ne[3] / src->ne[3], dst->ne[2] / src->ne[2], dst->ne[1] / src->ne[1], dst->ne[0] / src->ne[0]
+    };
 
     aclnn_repeat(ctx, acl_src, acl_dst, repeatsArray);
     ggml_cann_release_resources(ctx, acl_src, acl_dst);
 }
 
-void aclnn_add(ggml_backend_cann_context& ctx, aclTensor* acl_src0,
-                      aclTensor* acl_src1, aclTensor* acl_dst) {
-    float alphaValue = 1.0f;
-    aclScalar* alpha = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
-    if (acl_dst != nullptr)
+void aclnn_add(ggml_backend_cann_context & ctx, aclTensor * acl_src0, aclTensor * acl_src1, aclTensor * acl_dst) {
+    float       alphaValue = 1.0f;
+    aclScalar * alpha      = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
+    if (acl_dst != nullptr) {
         GGML_CANN_CALL_ACLNN_OP(ctx, Add, acl_src0, acl_src1, alpha, acl_dst);
-    else
+    } else {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceAdd, acl_src0, acl_src1, alpha);
+    }
     ggml_cann_release_resources(ctx, alpha);
 }
 
-void aclnn_sub(ggml_backend_cann_context& ctx, aclTensor* acl_src0,
-    aclTensor* acl_src1, aclTensor* acl_dst) {
-    float alphaValue = 1.0f;
-    aclScalar* alpha = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
-    if (acl_dst != nullptr)
+void aclnn_sub(ggml_backend_cann_context & ctx, aclTensor * acl_src0, aclTensor * acl_src1, aclTensor * acl_dst) {
+    float       alphaValue = 1.0f;
+    aclScalar * alpha      = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
+    if (acl_dst != nullptr) {
         GGML_CANN_CALL_ACLNN_OP(ctx, Sub, acl_src0, acl_src1, alpha, acl_dst);
-    else
+    } else {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceSub, acl_src0, acl_src1, alpha);
+    }
     ggml_cann_release_resources(ctx, alpha);
 }
 
-void aclnn_mul(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-    aclTensor* acl_other, aclTensor* acl_dst) {
-    if (acl_dst != nullptr)
+void aclnn_mul(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor * acl_other, aclTensor * acl_dst) {
+    if (acl_dst != nullptr) {
         GGML_CANN_CALL_ACLNN_OP(ctx, Mul, acl_src, acl_other, acl_dst);
-    else
+    } else {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceMul, acl_src, acl_other);
+    }
 }
 
-void aclnn_div(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-    aclTensor* acl_other, aclTensor* acl_dst) {
-    if (acl_dst != nullptr)
+void aclnn_div(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor * acl_other, aclTensor * acl_dst) {
+    if (acl_dst != nullptr) {
         GGML_CANN_CALL_ACLNN_OP(ctx, Div, acl_src, acl_other, acl_dst);
-    else
+    } else {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceDiv, acl_src, acl_other);
+    }
 }
 
 /**
@@ -260,9 +270,12 @@ void aclnn_div(ggml_backend_cann_context& ctx, aclTensor* acl_src,
  * @param inplace Flag indicating whether to perform the operation in-place on
  * `acl_src`.
  */
-static void aclnn_muls(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-    float scale, aclTensor* acl_dst, bool inplace) {
-    aclScalar* acl_scale = aclCreateScalar(&scale, aclDataType::ACL_FLOAT);
+static void aclnn_muls(ggml_backend_cann_context & ctx,
+                       aclTensor *                 acl_src,
+                       float                       scale,
+                       aclTensor *                 acl_dst,
+                       bool                        inplace) {
+    aclScalar * acl_scale = aclCreateScalar(&scale, aclDataType::ACL_FLOAT);
     if (inplace) {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceMuls, acl_src, acl_scale);
     } else {
@@ -271,19 +284,18 @@ static void aclnn_muls(ggml_backend_cann_context& ctx, aclTensor* acl_src,
     ggml_cann_release_resources(ctx, acl_scale);
 }
 
-void ggml_cann_leaky_relu(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_leaky_relu(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
 
     GGML_ASSERT(src->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     float negative_slope;
     memcpy(&negative_slope, dst->op_params, sizeof(float));
-    aclScalar* acl_negative_slope =
-        aclCreateScalar(&negative_slope, aclDataType::ACL_FLOAT);
+    aclScalar * acl_negative_slope = aclCreateScalar(&negative_slope, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, LeakyRelu, acl_src, acl_negative_slope, acl_dst);
     ggml_cann_release_resources(ctx, acl_negative_slope, acl_src, acl_dst);
@@ -299,26 +311,27 @@ void ggml_cann_leaky_relu(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * stored.
  * @param concat_dim The dimension along which the tensors will be concatenated.
  */
-static void aclnn_concat(ggml_backend_cann_context& ctx,
-                         aclTensorList* tensorList, aclTensor* acl_dst,
-                         int64_t concat_dim) {
+static void aclnn_concat(ggml_backend_cann_context & ctx,
+                         aclTensorList *             tensorList,
+                         aclTensor *                 acl_dst,
+                         int64_t                     concat_dim) {
     GGML_CANN_CALL_ACLNN_OP(ctx, Cat, tensorList, concat_dim, acl_dst);
 }
 
-void ggml_cann_concat(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];
-    ggml_tensor* src1 = dst->src[1];
-    aclTensor* acl_src0 = ggml_cann_create_tensor(src0);
-    aclTensor* acl_src1 = ggml_cann_create_tensor(src1);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+void ggml_cann_concat(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0     = dst->src[0];
+    ggml_tensor * src1     = dst->src[1];
+    aclTensor *   acl_src0 = ggml_cann_create_tensor(src0);
+    aclTensor *   acl_src1 = ggml_cann_create_tensor(src1);
+    aclTensor *   acl_dst  = ggml_cann_create_tensor(dst);
 
     const int32_t dim = ggml_get_op_params_i32(dst, 0);
 
     GGML_ASSERT(dim >= 0 && dim < 4);
     int32_t acl_dim = 3 - dim;
 
-    aclTensor* tensors[] = {acl_src0, acl_src1};
-    aclTensorList* tensor_list = aclCreateTensorList(tensors, 2);
+    aclTensor *     tensors[]   = { acl_src0, acl_src1 };
+    aclTensorList * tensor_list = aclCreateTensorList(tensors, 2);
     aclnn_concat(ctx, tensor_list, acl_dst, acl_dim);
 
     ggml_cann_release_resources(ctx, tensor_list, acl_dst);
@@ -341,162 +354,488 @@ void ggml_cann_concat(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param step The step size between consecutive values.
  * @param n_elements The number of elements in the destination tensor.
  */
-static void aclnn_arange(ggml_backend_cann_context& ctx, aclTensor* acl_dst,
-                         float start, float stop, float step,
-                         int64_t n_elements) {
-    int64_t steps = (int64_t)std::ceil((stop - start) / step);
+static void aclnn_arange(ggml_backend_cann_context & ctx,
+                         aclTensor *                 acl_dst,
+                         float                       start,
+                         float                       stop,
+                         float                       step,
+                         int64_t                     n_elements) {
+    int64_t steps = (int64_t) std::ceil((stop - start) / step);
     GGML_ASSERT(n_elements == steps);
 
-    aclScalar* acl_start = aclCreateScalar(&start, aclDataType::ACL_FLOAT);
-    aclScalar* acl_end = aclCreateScalar(&stop, aclDataType::ACL_FLOAT);
-    aclScalar* acl_step = aclCreateScalar(&step, aclDataType::ACL_FLOAT);
+    aclScalar * acl_start = aclCreateScalar(&start, aclDataType::ACL_FLOAT);
+    aclScalar * acl_end   = aclCreateScalar(&stop, aclDataType::ACL_FLOAT);
+    aclScalar * acl_step  = aclCreateScalar(&step, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, Arange, acl_start, acl_end, acl_step, acl_dst);
     ggml_cann_release_resources(ctx, acl_start, acl_end, acl_step);
 }
 
-void ggml_cann_arange(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
+void ggml_cann_arange(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     int64_t n_elements = ggml_nelements(dst);
-    float start;
-    float stop;
-    float step;
-    memcpy(&start, (float*)dst->op_params + 0, sizeof(float));
-    memcpy(&stop, (float*)dst->op_params + 1, sizeof(float));
-    memcpy(&step, (float*)dst->op_params + 2, sizeof(float));
+    float   start;
+    float   stop;
+    float   step;
+    memcpy(&start, (float *) dst->op_params + 0, sizeof(float));
+    memcpy(&stop, (float *) dst->op_params + 1, sizeof(float));
+    memcpy(&step, (float *) dst->op_params + 2, sizeof(float));
 
     aclnn_arange(ctx, acl_dst, start, stop, step, n_elements);
     ggml_cann_release_resources(ctx, acl_dst);
 }
 
-void ggml_cann_clamp(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_clamp(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
 
     float min;
     float max;
     memcpy(&min, dst->op_params, sizeof(float));
-    memcpy(&max, (float*)dst->op_params + 1, sizeof(float));
+    memcpy(&max, (float *) dst->op_params + 1, sizeof(float));
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
-    aclScalar* acl_min = aclCreateScalar(&min, aclDataType::ACL_FLOAT);
-    aclScalar* acl_max = aclCreateScalar(&max, aclDataType::ACL_FLOAT);
+    aclScalar * acl_min = aclCreateScalar(&min, aclDataType::ACL_FLOAT);
+    aclScalar * acl_max = aclCreateScalar(&max, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, Clamp, acl_src, acl_min, acl_max, acl_dst);
     ggml_cann_release_resources(ctx, acl_min, acl_max, acl_src, acl_dst);
 }
 
-void ggml_cann_scale(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_scale(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
 
     // scale factor
     float v;
     memcpy(&v, dst->op_params, sizeof(float));
 
-    aclScalar* scale = aclCreateScalar(&v, aclDataType::ACL_FLOAT);
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclScalar * scale   = aclCreateScalar(&v, aclDataType::ACL_FLOAT);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, Muls, acl_src, scale, acl_dst);
     ggml_cann_release_resources(ctx, scale, acl_src, acl_dst);
 }
 
-void ggml_cann_argsort(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
-    enum ggml_sort_order order = (enum ggml_sort_order)dst->op_params[0];
+void ggml_cann_argsort(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor *        src   = dst->src[0];
+    enum ggml_sort_order order = (enum ggml_sort_order) dst->op_params[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
-    ggml_cann_pool_alloc temp_buffer_allocator(
-        ctx.pool(), ggml_nelements(dst) * sizeof(int64_t));
-    void* buffer = temp_buffer_allocator.get();
-    aclTensor* tmp_tensor =
-        ggml_cann_create_tensor(buffer, ACL_INT64, ggml_type_size(dst->type),
-                                dst->ne, dst->nb, GGML_MAX_DIMS);
-    GGML_CANN_CALL_ACLNN_OP(ctx, Argsort, acl_src, -1, (order == GGML_SORT_ORDER_DESC ? true : false),
-                      tmp_tensor);
+    aclTensor *          acl_src = ggml_cann_create_tensor(src);
+    aclTensor *          acl_dst = ggml_cann_create_tensor(dst);
+    ggml_cann_pool_alloc temp_buffer_allocator(ctx.pool(), ggml_nelements(dst) * sizeof(int64_t));
+    void *               buffer = temp_buffer_allocator.get();
+    aclTensor *          tmp_tensor =
+        ggml_cann_create_tensor(buffer, ACL_INT64, ggml_type_size(dst->type), dst->ne, dst->nb, GGML_MAX_DIMS);
+    GGML_CANN_CALL_ACLNN_OP(ctx, Argsort, acl_src, -1, (order == GGML_SORT_ORDER_DESC ? true : false), tmp_tensor);
     GGML_CANN_CALL_ACLNN_OP(ctx, Cast, tmp_tensor, ggml_cann_type_mapping(dst->type), acl_dst);
     ggml_cann_release_resources(ctx, acl_src, tmp_tensor, acl_dst);
 }
 
-void ggml_cann_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+static inline void ggml_cann_out_prod_f32(
+    ggml_backend_cann_context & ctx,
+    ggml_tensor * src0,      // src0 (F32)
+    ggml_tensor * src1,      // src1 (F32)
+    ggml_tensor * dst) {     // dst  (F32)
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    GGML_ASSERT(src0  && src1 && dst);
+    GGML_ASSERT(src0->type  == GGML_TYPE_F32);
+    GGML_ASSERT(src1->type  == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+
+    GGML_TENSOR_BINARY_OP_LOCALS;
+
+    GGML_ASSERT(dst->ne[0] == ne00);
+    GGML_ASSERT(dst->ne[1] == ne10);
+
+    // B 与 C 的批维一致；A 的批维可被 C 整数倍复制
+    GGML_ASSERT(ne2 == ne12);
+    GGML_ASSERT(ne3 == ne13);
+
+    // K 维：允许 A 或 B 为 1 来广播
+    const int64_t K = std::max(ne01, ne11);
+    GGML_ASSERT(ne01 == 1 || ne11 == 1 || ne01 == ne11);
+
+    // 分组复制系数
+    const int64_t A_ne2 = std::max<int64_t>(ne02, 1);
+    const int64_t A_ne3 = std::max<int64_t>(ne03, 1);
+
+    GGML_ASSERT(ne2 % A_ne2 == 0);
+    GGML_ASSERT(ne3 % A_ne3 == 0);
+    const int64_t dps2 = ne2 / A_ne2;  // 每个 A.i2 复制 dps2 次到 C
+    const int64_t dps3 = ne3 / A_ne3;  // 每个 A.i3 复制 dps3 次到 C
+
+    // K 维广播（步长置 0 ）
+    const size_t A_nbK = (ne01 == 1 && K > 1) ? 0 : sizeof(float) * ne00;
+    const size_t B_nbK = (ne11 == 1 && K > 1) ? 0 : nb11;
+
+    // 工具：构造 3D ND tensor [1, D1, D2]
+    auto make_acl3 = [&](ggml_tensor * t,
+                     size_t byte_offset,
+                     int64_t M, int64_t N,
+                     size_t nbM, size_t nbN) -> aclTensor * {
+        int64_t ne_in[3] = { N, M, 1 };   // 预反转
+        size_t  nb_in[3] = { nbN, nbM, 0 }; // batch 维步长 0 → 单批
+        return ggml_cann_create_tensor(t, ne_in, nb_in, /*dims=*/3, ACL_FORMAT_ND, byte_offset);
+    };
+
+    // 遍历 C 的每个批块，计算 A/B 的对应批块
+    for (int64_t c_i3 = 0; c_i3 < ne3; ++c_i3) {
+        for (int64_t c_i2 = 0; c_i2 < ne2; ++c_i2) {
+            // C 的批索引
+            const size_t c_off = (size_t)c_i2 * nb2 + (size_t)c_i3 * nb3;
+
+            // A 的批索引（分组复制：用“整除”）
+            const int64_t a_i2 = (A_ne2 == 1) ? 0 : (c_i2 / dps2);
+            const int64_t a_i3 = (A_ne3 == 1) ? 0 : (c_i3 / dps3);
+            const size_t  a_off = (size_t)a_i2 * nb02 + (size_t)a_i3 * nb03;
+
+            // B 的批索引（与 C 一致，无分组）
+            const int64_t b_i2 = (ne12 == 0) ? 0 : c_i2;
+            const int64_t b_i3 = (ne13 == 0) ? 0 : c_i3;
+            const size_t  b_off = (size_t)b_i2 * nb12 + (size_t)b_i3 * nb13;
+
+            // A: [I, K]  →  make_acl3(M=I, N=K, nbM=A_nb0, nbN=A_nb1)
+            aclTensor * acl_src0 = make_acl3(src0,  a_off, /*M*/ ne00, /*N*/ K,
+                                        /*nbM*/ nb00, /*nbN*/ A_nbK);
+
+            // B: [K, J]  →  make_acl3(M=K, N=J, nbM=B_nb1, nbN=B_nb0)
+            aclTensor * acl_src1 = make_acl3(src1,  b_off, /*M*/ K, /*N*/ ne10,
+                                        /*nbM*/ B_nbK, /*nbN*/ nb10);
+
+            // C: [I, J]  →  make_acl3(M=I, N=J, nbM=C_nb0, nbN=C_nb1)
+            aclTensor * acl_dst = make_acl3(dst, c_off, /*M*/ ne00, /*N*/ ne10,
+                                        /*nbM*/ nb0, /*nbN*/ nb1);
+
+            const int8_t transpose_x1 = 0;
+            GGML_CANN_CALL_ACLNN_OP(
+                ctx, BatchMatMul,
+                /*x1=*/acl_src0,
+                /*x2=*/acl_src1,
+                /*out=*/acl_dst,
+                /*transpose_x1=*/transpose_x1
+            );
+
+            ggml_cann_release_resources(ctx, acl_src0, acl_src1, acl_dst);
+        }
+    }
+}
+
+static inline void ggml_cann_out_prod_q0_f32(ggml_backend_cann_context & ctx,
+                                             ggml_tensor *               src0,  // src0 (quantized)
+                                             ggml_tensor *               src1,  // src1 (F32/F16)
+                                             ggml_tensor *               dst){
+    GGML_ASSERT(src0 && src1 && dst);
+    GGML_ASSERT(dst->type  == GGML_TYPE_F32);
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(src0->type == GGML_TYPE_Q4_0 || src0->type == GGML_TYPE_Q8_0);
+    
+    GGML_ASSERT(src0 != nullptr);
+    GGML_ASSERT(ggml_is_quantized(src0->type));
+
+    // 维度与步长（ggml 约定：ne[0] 为最快维）
+    const int64_t ne0 = src0->ne[0];
+    const int64_t ne1 = src0->ne[1];
+    const int64_t ne2 = src0->ne[2];
+    const int64_t ne3 = src0->ne[3];
+
+    // 量化行通常要求：dim0 逐元素紧致
+    GGML_ASSERT(src0->nb[0] == ggml_type_size(src0->type));
+
+    // 1) 从后端取回到主机，后端会做 transform_back，得到 ggml 原生量化排布
+    const size_t qbytes = ggml_nbytes(src0);
+    std::vector<uint8_t> host_q(qbytes);
+    ggml_backend_tensor_get(src0, host_q.data(), /*offset=*/0, qbytes);
+
+    // 2) 主机侧逐行反量化为 F32
+    const size_t n_elem = (size_t)ne0*ne1*ne2*ne3;
+    std::vector<float> host_f32(n_elem);
+
+    ggml_to_float_t deq_row = ggml_get_type_traits(src0->type)->to_float;
+    GGML_ASSERT(deq_row != nullptr);
+
+    const size_t nb01 = src0->nb[1];
+    const size_t nb02 = src0->nb[2];
+    const size_t nb03 = src0->nb[3];
+
+    size_t row = 0;
+    for (int64_t i3 = 0; i3 < ne3; ++i3) {
+        for (int64_t i2 = 0; i2 < ne2; ++i2) {
+            for (int64_t i1 = 0; i1 < ne1; ++i1) {
+                const void *qptr = (const void *)((const char*)host_q.data() + i1*nb01 + i2*nb02 + i3*nb03);
+                float *fptr = host_f32.data() + row*ne0;
+                deq_row(qptr, fptr, (int)ne0);
+                ++row;
+            }
+        }
+    }
+
+    // 3) 申请设备侧 F32 buffer 并拷贝
+    void *dev_ptr = nullptr;
+    const size_t f32_bytes = n_elem*sizeof(float);
+    ACL_CHECK(aclrtMalloc(&dev_ptr, f32_bytes, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(dev_ptr, f32_bytes, host_f32.data(), f32_bytes,
+                          ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // 4) 构造一个最小 ggml_tensor 壳，描述这块 F32 设备内存（行主序致密）
+    ggml_tensor *tmp = new ggml_tensor();
+    memset(tmp, 0, sizeof(*tmp));
+    tmp->type = GGML_TYPE_F32;
+    tmp->ne[0] = ne0; tmp->ne[1] = ne1; tmp->ne[2] = ne2; tmp->ne[3] = ne3;
+    tmp->nb[0] = sizeof(float);
+    tmp->nb[1] = tmp->nb[0]*ne0;
+    tmp->nb[2] = tmp->nb[1]*ne1;
+    tmp->nb[3] = tmp->nb[2]*ne2;
+    tmp->data  = dev_ptr;
+    
+    ggml_cann_out_prod_f32(ctx, tmp, src1, dst);
+    
+    if (!tmp) return;
+    if (tmp->data) {
+        ACL_CHECK(aclrtFree(tmp->data));
+        tmp->data = nullptr;
+    }
+    delete tmp;
+    GGML_UNUSED(ctx);
+}
+
+static inline void ggml_cann_out_prod_q_f32(
+    ggml_backend_cann_context & ctx,
+    ggml_tensor * src0,      // src0 (quantized)
+    ggml_tensor * src1,      // src1 (F32)
+    ggml_tensor * dst) {     // dst  (F32)
+
+    GGML_ASSERT(src0  && src1 && dst);
+    GGML_ASSERT(src1->type  == GGML_TYPE_F32);
+    GGML_ASSERT(dst->type == GGML_TYPE_F32);
+
+    GGML_TENSOR_BINARY_OP_LOCALS;
+
+    GGML_ASSERT(dst->ne[0] == ne00);
+    GGML_ASSERT(dst->ne[1] == ne10);
+
+    // B 与 C 的批维一致；A 的批维可被 C 整数倍复制
+    GGML_ASSERT(ne2 == ne12);
+    GGML_ASSERT(ne3 == ne13);
+
+    // K 维：允许 A 或 B 为 1 来广播
+    const int64_t K = std::max(ne01, ne11);
+    GGML_ASSERT(ne01 == 1 || ne11 == 1 || ne01 == ne11);
+
+    // 分组复制系数
+    const int64_t A_ne2 = std::max<int64_t>(ne02, 1);
+    const int64_t A_ne3 = std::max<int64_t>(ne03, 1);
+
+    GGML_ASSERT(ne2 % A_ne2 == 0);
+    GGML_ASSERT(ne3 % A_ne3 == 0);
+    const int64_t dps2 = ne2 / A_ne2;  // 每个 A.i2 复制 dps2 次到 C
+    const int64_t dps3 = ne3 / A_ne3;  // 每个 A.i3 复制 dps3 次到 C
+
+    // K 维广播
+    const size_t B_nbK = (ne11 == 1 && K > 1) ? 0 : nb11;
+
+    // 工具：构造 3D ND tensor [1, D1, D2]
+    auto make_acl3 = [&](ggml_tensor * t,
+                     size_t byte_offset,
+                     int64_t M, int64_t N,
+                     size_t nbM, size_t nbN) -> aclTensor * {
+        int64_t ne_in[3] = { N, M, 1 };   // 预反转
+        size_t  nb_in[3] = { nbN, nbM, 0 }; // batch 维步长 0 → 单批
+        return ggml_cann_create_tensor(t, ne_in, nb_in, /*dims=*/3, ACL_FORMAT_ND, byte_offset);
+    };
+
+    auto make_acl3_buffer = [&](void * buffer,
+                            size_t byte_offset,
+                            int64_t M, int64_t N,
+                            size_t nbM, size_t nbN) -> aclTensor * {
+        int64_t ne_in[3] = { N, M, 1 };   // 预反转
+        size_t  nb_in[3] = { nbN, nbM, 0 }; // batch 维步长 0 → 单批
+        return ggml_cann_create_tensor(buffer, ACL_FLOAT, sizeof(float), ne_in, nb_in, /*dims=*/3, ACL_FORMAT_ND, byte_offset);
+    };
+
+    // 主机侧反量化缓冲区 + 设备侧临时缓冲区
+    std::vector<float> dequant_host((size_t) ne00 * K);
+    ggml_cann_pool_alloc dequant_device_allocator(ctx.pool(), (size_t) ne00 * K * sizeof(float));
+    void * dequant_device = dequant_device_allocator.get();
+    const size_t dequant_bytes = (size_t) ne00 * K * sizeof(float);
+    const size_t quant_size = (size_t)K * nb01;
+    std::vector<char> quant_host(quant_size);
+
+    // A 的步长（支持 K 维广播）
+    const size_t A_nbM = sizeof(float);
+    const size_t A_nbK = (ne01 == 1 && K > 1) ? 0 : sizeof(float) * ne00;
+
+    // 遍历 C 的每个批块，计算 A/B 的对应批块
+    for (int64_t c_i3 = 0; c_i3 < ne3; ++c_i3) {
+        for (int64_t c_i2 = 0; c_i2 < ne2; ++c_i2) {
+            // C 的批索引
+            const size_t c_off = (size_t)c_i2 * nb2 + (size_t)c_i3 * nb3;
+
+            // A 的批索引（分组复制：用"整除"）
+            const int64_t a_i2 = (A_ne2 == 1) ? 0 : (c_i2 / dps2);
+            const int64_t a_i3 = (A_ne3 == 1) ? 0 : (c_i3 / dps3);
+            const size_t  a_off = (size_t)a_i2 * nb02 + (size_t)a_i3 * nb03;
+
+            // B 的批索引（与 C 一致，无分组）
+            const int64_t b_i2 = (ne12 == 0) ? 0 : c_i2;
+            const int64_t b_i3 = (ne13 == 0) ? 0 : c_i3;
+            const size_t  b_off = (size_t)b_i2 * nb12 + (size_t)b_i3 * nb13;
+
+            // 复制量化数据到主机缓冲区
+            ggml_cann_async_memcpy(ctx, quant_host.data(), (const char *) src0->data + a_off, quant_size, ACL_MEMCPY_DEVICE_TO_HOST);
+            ACL_CHECK(aclrtSynchronizeStream(ctx.stream()));
+
+            // 在主机上反量化
+            ggml_to_float_t const dequantize_row_q = ggml_get_type_traits(src0->type)->to_float;
+            for (int64_t k = 0; k < K; ++k) {
+                const int64_t row_idx = (ne01 == 1) ? 0 : k;
+                const void * q_row = quant_host.data() + (size_t) row_idx * nb01;
+                float * f_row = dequant_host.data() + (size_t)k * ne00;
+                dequantize_row_q(q_row, f_row, ne00);
+            }
+
+            // 拷贝到设备
+            ggml_cann_async_memcpy(ctx, dequant_device, dequant_host.data(), dequant_bytes, ACL_MEMCPY_HOST_TO_DEVICE);
+
+            // A: [I, K]  →  make_acl3(M=I, N=K, nbM=A_nb0, nbN=A_nb1)
+            aclTensor * acl_src0 = make_acl3_buffer(dequant_device, 0, ne00, K, A_nbM, A_nbK);
+
+            // B: [K, J]  →  make_acl3(M=K, N=J, nbM=B_nb1, nbN=B_nb0)
+            aclTensor * acl_src1 = make_acl3(src1,  b_off, /*M*/ K, /*N*/ ne10,
+                                        /*nbM*/ B_nbK, /*nbN*/ nb10);
+
+            // C: [I, J]  →  make_acl3(M=I, N=J, nbM=C_nb0, nbN=C_nb1)
+            aclTensor * acl_dst = make_acl3(dst, c_off, /*M*/ ne00, /*N*/ ne10,
+                                        /*nbM*/ nb0, /*nbN*/ nb1);
+
+            const int8_t transpose_x1 = 0;
+            GGML_CANN_CALL_ACLNN_OP(
+                ctx, BatchMatMul,
+                /*x1=*/acl_src0,
+                /*x2=*/acl_src1,
+                /*out=*/acl_dst,
+                /*transpose_x1=*/transpose_x1
+            );
+
+            ggml_cann_release_resources(ctx, acl_src0, acl_src1, acl_dst);
+
+            // 同步，确保下一个批次能复用反量化缓冲区
+            ACL_CHECK(aclrtSynchronizeStream(ctx.stream()));
+        }
+    }
+}
+
+// ================ OUT_PROD ====================
+void ggml_cann_out_prod(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * A = dst->src[0];
+    ggml_tensor * B = dst->src[1];
+
+    switch (A->type) {
+        case GGML_TYPE_F32:
+            {
+                ggml_cann_out_prod_f32(ctx, A, B, dst);
+            }
+            break;
+        case GGML_TYPE_F16:
+            {
+                GGML_ABORT("fatal error");  // todo(BOTH at CPU end)
+            }
+            break;
+        case GGML_TYPE_Q8_0:
+        case GGML_TYPE_Q4_0:
+            {
+                ggml_cann_out_prod_q0_f32(ctx, A, B, dst);
+            }
+            break;
+        case GGML_TYPE_Q4_1:
+        case GGML_TYPE_Q4_K:
+        case GGML_TYPE_MXFP4:
+        case GGML_TYPE_IQ2_XXS:
+            {
+                ggml_cann_out_prod_q_f32(ctx, A, B, dst);
+            }
+            break;
+        default:
+            {
+                GGML_ABORT("Unsupported type for out_prod");
+            }
+            break;
+    }
+}
+
+void ggml_cann_norm(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
+
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     float eps;
     memcpy(&eps, dst->op_params, sizeof(float));
 
-    std::vector<int64_t> normData = {dst->ne[0]};
-    aclIntArray* norm = aclCreateIntArray(normData.data(), normData.size());
-    GGML_CANN_CALL_ACLNN_OP(ctx, LayerNorm, acl_src, norm, nullptr, nullptr,
-                    eps, acl_dst, nullptr, nullptr);
+    std::vector<int64_t> normData = { dst->ne[0] };
+    aclIntArray *        norm     = aclCreateIntArray(normData.data(), normData.size());
+    GGML_CANN_CALL_ACLNN_OP(ctx, LayerNorm, acl_src, norm, nullptr, nullptr, eps, acl_dst, nullptr, nullptr);
     ggml_cann_release_resources(ctx, norm, acl_src, acl_dst);
 }
 
-void ggml_cann_group_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_group_norm(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     int n_groups = dst->op_params[0];
 
     float eps;
     memcpy(&eps, dst->op_params + 1, sizeof(float));
 
-    int64_t N = src->ne[3];
-    int64_t C = src->ne[2];
+    int64_t N   = src->ne[3];
+    int64_t C   = src->ne[2];
     int64_t HxW = src->ne[1] * src->ne[0];
 
-    size_t type_size = ggml_type_size(src->type);
-    int64_t ne[] = {n_groups, N};
-    size_t nb[] = {type_size, type_size * n_groups};
-    size_t n_bytes = N * n_groups;
+    size_t  type_size = ggml_type_size(src->type);
+    int64_t ne[]      = { n_groups, N };
+    size_t  nb[]      = { type_size, type_size * n_groups };
+    size_t  n_bytes   = N * n_groups;
 
     ggml_cann_pool_alloc temp_buffer_allocator(ctx.pool(), n_bytes * 2);
-    void* buffer = temp_buffer_allocator.get();
-    aclTensor* acl_mean_out = ggml_cann_create_tensor(
-        buffer, ACL_FLOAT, type_size, ne, nb, ACL_FORMAT_ND);
-    aclTensor* acl_rstd_out = ggml_cann_create_tensor(
-        (char*)buffer + n_bytes, ACL_FLOAT, type_size, ne, nb, ACL_FORMAT_ND);
+    void *               buffer       = temp_buffer_allocator.get();
+    aclTensor *          acl_mean_out = ggml_cann_create_tensor(buffer, ACL_FLOAT, type_size, ne, nb, ACL_FORMAT_ND);
+    aclTensor *          acl_rstd_out =
+        ggml_cann_create_tensor((char *) buffer + n_bytes, ACL_FLOAT, type_size, ne, nb, ACL_FORMAT_ND);
 
-    GGML_CANN_CALL_ACLNN_OP(ctx, GroupNorm, acl_src, nullptr, nullptr, N, C, HxW, n_groups, eps,
-        acl_dst, acl_mean_out, acl_rstd_out);
+    GGML_CANN_CALL_ACLNN_OP(
+        ctx, GroupNorm, acl_src, nullptr, nullptr, N, C, HxW, n_groups, eps, acl_dst, acl_mean_out, acl_rstd_out);
     ggml_cann_release_resources(ctx, acl_src, acl_dst, acl_mean_out, acl_rstd_out);
 }
 
-void ggml_cann_acc(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];
-    ggml_tensor* src1 = dst->src[1];
+void ggml_cann_acc(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0 = dst->src[0];
+    ggml_tensor * src1 = dst->src[1];
 
-    size_t nb1 = ((int32_t*)dst->op_params)[0];
-    size_t nb2 = ((int32_t*)dst->op_params)[1];
-    size_t nb3 = ((int32_t*)dst->op_params)[2];
-    size_t offset = ((int32_t*)dst->op_params)[3];
-    bool inplace = (bool)((int32_t*)dst->op_params)[4];
+    size_t nb1     = ((int32_t *) dst->op_params)[0];
+    size_t nb2     = ((int32_t *) dst->op_params)[1];
+    size_t nb3     = ((int32_t *) dst->op_params)[2];
+    size_t offset  = ((int32_t *) dst->op_params)[3];
+    bool   inplace = (bool) ((int32_t *) dst->op_params)[4];
 
-    size_t param_nb[] = {ggml_element_size(src0), nb1, nb2, nb3};
+    size_t param_nb[] = { ggml_element_size(src0), nb1, nb2, nb3 };
 
-    aclTensor* acl_dst = ggml_cann_create_tensor(
-        dst, src1->ne, param_nb, GGML_MAX_DIMS, ACL_FORMAT_ND, offset);
-    aclTensor* acl_src1 = ggml_cann_create_tensor(src1);
+    aclTensor * acl_dst  = ggml_cann_create_tensor(dst, src1->ne, param_nb, GGML_MAX_DIMS, ACL_FORMAT_ND, offset);
+    aclTensor * acl_src1 = ggml_cann_create_tensor(src1);
 
-    aclScalar* alpha = nullptr;
-    float alphaValue = 1.0f;
-    alpha = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
+    aclScalar * alpha      = nullptr;
+    float       alphaValue = 1.0f;
+    alpha                  = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
 
     if (!inplace) {
         size_t cpy_size = ggml_nbytes(dst);
-        ggml_cann_async_memcpy(ctx, dst->data, src0->data, cpy_size,
-            ACL_MEMCPY_DEVICE_TO_DEVICE);
-        aclTensor* acl_src0 = ggml_cann_create_tensor(
-            src0, src1->ne, src0->nb, GGML_MAX_DIMS, ACL_FORMAT_ND, offset);
+        ggml_cann_async_memcpy(ctx, dst->data, src0->data, cpy_size, ACL_MEMCPY_DEVICE_TO_DEVICE);
+        aclTensor * acl_src0 = ggml_cann_create_tensor(src0, src1->ne, src0->nb, GGML_MAX_DIMS, ACL_FORMAT_ND, offset);
 
         GGML_CANN_CALL_ACLNN_OP(ctx, Add, acl_src0, acl_src1, alpha, acl_dst);
         ggml_cann_release_resources(ctx, acl_src0);
@@ -516,39 +855,34 @@ void ggml_cann_acc(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param dim An array of dimension indices.
  * @param dim_size The number of dimensions.
  */
-static void aclnn_reduce_sum(ggml_backend_cann_context& ctx, ggml_tensor* dst,
-                             int64_t* dim, size_t dim_size) {
+static void aclnn_reduce_sum(ggml_backend_cann_context & ctx, ggml_tensor * dst, int64_t * dim, size_t dim_size) {
     GGML_ASSERT(dst->ne[0] == 1);
-    ggml_tensor* src = dst->src[0];
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
-    aclIntArray* reduce_dims = aclCreateIntArray(dim, dim_size);
+    ggml_tensor * src         = dst->src[0];
+    aclTensor *   acl_src     = ggml_cann_create_tensor(src);
+    aclTensor *   acl_dst     = ggml_cann_create_tensor(dst);
+    aclIntArray * reduce_dims = aclCreateIntArray(dim, dim_size);
 
-    GGML_CANN_CALL_ACLNN_OP(ctx, ReduceSum, acl_src, reduce_dims, true,
-                      ggml_cann_type_mapping(dst->type), acl_dst);
+    GGML_CANN_CALL_ACLNN_OP(ctx, ReduceSum, acl_src, reduce_dims, true, ggml_cann_type_mapping(dst->type), acl_dst);
     ggml_cann_release_resources(ctx, acl_src, acl_dst, reduce_dims);
 }
 
-void ggml_cann_sum_rows(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    int64_t reduce_dims[] = {3};
+void ggml_cann_sum_rows(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    int64_t reduce_dims[] = { 3 };
     aclnn_reduce_sum(ctx, dst, reduce_dims, 1);
 }
 
-void ggml_cann_sum(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    int64_t reduce_dims[] = {0, 1, 2, 3};
+void ggml_cann_sum(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    int64_t reduce_dims[] = { 0, 1, 2, 3 };
     aclnn_reduce_sum(ctx, dst, reduce_dims, 4);
 }
 
-void ggml_cann_upsample_nearest2d(ggml_backend_cann_context& ctx,
-                                  ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
-    aclTensor* acl_src =
-        ggml_cann_create_tensor(src, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
-    aclTensor* acl_dst =
-        ggml_cann_create_tensor(dst, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
+void ggml_cann_upsample_nearest2d(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src     = dst->src[0];
+    aclTensor *   acl_src = ggml_cann_create_tensor(src, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
+    aclTensor *   acl_dst = ggml_cann_create_tensor(dst, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
 
-    std::vector<int64_t> output_size{dst->ne[1], dst->ne[0]};
-    auto output_size_array = aclCreateIntArray(output_size.data(), 2);
+    std::vector<int64_t> output_size{ dst->ne[1], dst->ne[0] };
+    auto                 output_size_array = aclCreateIntArray(output_size.data(), 2);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, UpsampleNearest2d, acl_src, output_size_array, acl_dst);
     ggml_cann_release_resources(ctx, acl_src, acl_dst, output_size_array);
@@ -568,28 +902,29 @@ void ggml_cann_upsample_nearest2d(ggml_backend_cann_context& ctx,
  * The size of the array should be twice the number of dimensions of the tensor.
  * @param value The value to be used for padding. The default value is 0.0.
  */
-static void aclnn_pad(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                      aclTensor* acl_dst, int64_t* paddings,
-                      float value = 0.0f) {
-    aclIntArray* acl_pad = aclCreateIntArray(paddings, GGML_MAX_DIMS * 2);
-    aclScalar* acl_value = aclCreateScalar(&value, aclDataType::ACL_FLOAT);
+static void aclnn_pad(ggml_backend_cann_context & ctx,
+                      aclTensor *                 acl_src,
+                      aclTensor *                 acl_dst,
+                      int64_t *                   paddings,
+                      float                       value = 0.0f) {
+    aclIntArray * acl_pad   = aclCreateIntArray(paddings, GGML_MAX_DIMS * 2);
+    aclScalar *   acl_value = aclCreateScalar(&value, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, ConstantPadNd, acl_src, acl_pad, acl_value, acl_dst);
     ggml_cann_release_resources(ctx, acl_pad, acl_value);
 }
 
-void ggml_cann_pad(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+void ggml_cann_pad(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src     = dst->src[0];
+    aclTensor *   acl_src = ggml_cann_create_tensor(src);
+    aclTensor *   acl_dst = ggml_cann_create_tensor(dst);
 
     // padding: value in the array means how much distance will be padding.
     // the position of elements in the array means which dirction to padding,
     // each position means: [dim0.front, dim0.behind, dim1.front, dim1.behind,
     //                       dim2.front, dim2.behind, dim3.front, dim3.behind]
-    int64_t paddings[] = {
-        0, dst->ne[0] - src->ne[0], 0, dst->ne[1] - src->ne[1],
-        0, dst->ne[2] - src->ne[2], 0, dst->ne[3] - src->ne[3]};
+    int64_t paddings[] = { 0, dst->ne[0] - src->ne[0], 0, dst->ne[1] - src->ne[1],
+                           0, dst->ne[2] - src->ne[2], 0, dst->ne[3] - src->ne[3] };
     aclnn_pad(ctx, acl_src, acl_dst, paddings);
     ggml_cann_release_resources(ctx, acl_src, acl_dst);
 }
@@ -606,46 +941,50 @@ void ggml_cann_pad(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param dst The destination tensor where the result will be stored. The source
  * tensor is referenced by `dst->src[0]`.
  */
-static void ggml_cann_avg_pool2d(ggml_backend_cann_context& ctx,
-                                 ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+static void ggml_cann_avg_pool2d(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
     GGML_ASSERT(src->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
-    aclTensor* acl_src =
-        ggml_cann_create_tensor(src, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
-    aclTensor* acl_dst =
-        ggml_cann_create_tensor(dst, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
+    aclTensor * acl_src = ggml_cann_create_tensor(src, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
 
-    const int32_t* opts = (const int32_t*)dst->op_params;
-    const int k0 = opts[1];
-    const int k1 = opts[2];
-    const int s0 = opts[3];
-    const int s1 = opts[4];
-    const int p0 = opts[5];
-    const int p1 = opts[6];
+    const int32_t * opts = (const int32_t *) dst->op_params;
+    const int       k0   = opts[1];
+    const int       k1   = opts[2];
+    const int       s0   = opts[3];
+    const int       s1   = opts[4];
+    const int       p0   = opts[5];
+    const int       p1   = opts[6];
 
-    std::vector<int64_t> kernel_dims = {k1, k0};
-    std::vector<int64_t> stride_dims = {s1, s0};
-    std::vector<int64_t> padding_avg_dims = {p1, p0};  // (padH, padW)
+    std::vector<int64_t> kernel_dims      = { k1, k0 };
+    std::vector<int64_t> stride_dims      = { s1, s0 };
+    std::vector<int64_t> padding_avg_dims = { p1, p0 };  // (padH, padW)
 
-    auto* kernel_size = aclCreateIntArray(kernel_dims.data(), 2);
-    auto* strides = aclCreateIntArray(stride_dims.data(), 2);
-    auto* paddings_avg = aclCreateIntArray(padding_avg_dims.data(), 2);
+    auto * kernel_size  = aclCreateIntArray(kernel_dims.data(), 2);
+    auto * strides      = aclCreateIntArray(stride_dims.data(), 2);
+    auto * paddings_avg = aclCreateIntArray(padding_avg_dims.data(), 2);
 
-    bool ceil_mode = false;
-    bool count_include_pad = true;
-    int64_t divisor_override = 0;
-    int8_t cube_math_type = 0;
+    bool    ceil_mode         = false;
+    bool    count_include_pad = true;
+    int64_t divisor_override  = 0;
+    int8_t  cube_math_type    = 0;
 #ifdef ASCEND_310P
     cube_math_type = 1;
 #endif
 
-    GGML_CANN_CALL_ACLNN_OP(ctx, AvgPool2d, acl_src, kernel_size, strides, paddings_avg,
-                    ceil_mode, count_include_pad, divisor_override,
-                    cube_math_type, acl_dst);
-    ggml_cann_release_resources(ctx, acl_src, acl_dst, kernel_size, strides,
-                                paddings_avg);
+    GGML_CANN_CALL_ACLNN_OP(ctx,
+                            AvgPool2d,
+                            acl_src,
+                            kernel_size,
+                            strides,
+                            paddings_avg,
+                            ceil_mode,
+                            count_include_pad,
+                            divisor_override,
+                            cube_math_type,
+                            acl_dst);
+    ggml_cann_release_resources(ctx, acl_src, acl_dst, kernel_size, strides, paddings_avg);
 }
 
 /**
@@ -660,68 +999,61 @@ static void ggml_cann_avg_pool2d(ggml_backend_cann_context& ctx,
  * @param dst The destination tensor where the result will be stored. The source
  * tensor is referenced by `dst->src[0]`.
  */
-static void ggml_cann_max_pool2d(ggml_backend_cann_context& ctx,
-                                 ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+static void ggml_cann_max_pool2d(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
     GGML_ASSERT(src->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
-    aclTensor* acl_src =
-        ggml_cann_create_tensor(src, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
-    aclTensor* acl_dst =
-        ggml_cann_create_tensor(dst, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
+    aclTensor * acl_src = ggml_cann_create_tensor(src, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst, nullptr, nullptr, 0, ACL_FORMAT_NCHW);
 
-    const int32_t* opts = (const int32_t*)dst->op_params;
-    const int k0 = opts[1];
-    const int k1 = opts[2];
-    const int s0 = opts[3];
-    const int s1 = opts[4];
-    const int p0 = opts[5];
-    const int p1 = opts[6];
+    const int32_t * opts = (const int32_t *) dst->op_params;
+    const int       k0   = opts[1];
+    const int       k1   = opts[2];
+    const int       s0   = opts[3];
+    const int       s1   = opts[4];
+    const int       p0   = opts[5];
+    const int       p1   = opts[6];
 
-    int64_t temp_ne[] = {src->ne[0] + p0 * 2, src->ne[1] + p1 * 2, src->ne[2],
-                         src->ne[3]};
-    size_t temp_nb[GGML_MAX_DIMS];
+    int64_t temp_ne[] = { src->ne[0] + p0 * 2, src->ne[1] + p1 * 2, src->ne[2], src->ne[3] };
+    size_t  temp_nb[GGML_MAX_DIMS];
 
     temp_nb[0] = ggml_element_size(src);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         temp_nb[i] = temp_nb[i - 1] * temp_ne[i - 1];
     }
 
-    ggml_cann_pool_alloc temp_buffer_allocator(
-        ctx.pool(), ggml_nbytes(src) + p0 * 2 + p1 * 2 * src->nb[1]);
-    void* buffer = temp_buffer_allocator.get();
-    aclTensor* tmp_tensor = ggml_cann_create_tensor(
-        buffer, ACL_FLOAT, ggml_element_size(src), temp_ne, temp_nb,
-        GGML_MAX_DIMS, ACL_FORMAT_NCHW);
+    ggml_cann_pool_alloc temp_buffer_allocator(ctx.pool(), ggml_nbytes(src) + p0 * 2 + p1 * 2 * src->nb[1]);
+    void *               buffer     = temp_buffer_allocator.get();
+    aclTensor *          tmp_tensor = ggml_cann_create_tensor(
+        buffer, ACL_FLOAT, ggml_element_size(src), temp_ne, temp_nb, GGML_MAX_DIMS, ACL_FORMAT_NCHW);
 
     // pad: see padding in ggml_cann_pad()
-    int64_t paddings[] = {p0, p0, p1, p1, 0, 0, 0, 0};
-    float value = -FLT_MAX;
+    int64_t paddings[] = { p0, p0, p1, p1, 0, 0, 0, 0 };
+    float   value      = -FLT_MAX;
     aclnn_pad(ctx, acl_src, tmp_tensor, paddings, value);
 
     // max_pool
-    std::vector<int64_t> kernel_dims = {k1, k0};
-    std::vector<int64_t> stride_dims = {s1, s0};
+    std::vector<int64_t> kernel_dims      = { k1, k0 };
+    std::vector<int64_t> stride_dims      = { s1, s0 };
     // padding_max_dims: [dim0_start, dim0_end, dim1_start, dim1_end]
-    std::vector<int64_t> padding_max_dims = {0, 0, 0, 0};
-    std::vector<int64_t> dilation_size = {1, 1};
-    auto* kernel_size = aclCreateIntArray(kernel_dims.data(), 2);
-    auto* strides = aclCreateIntArray(stride_dims.data(), 2);
-    auto* paddings_max = aclCreateIntArray(padding_max_dims.data(), 4);
-    auto* dilations = aclCreateIntArray(dilation_size.data(), 2);
+    std::vector<int64_t> padding_max_dims = { 0, 0, 0, 0 };
+    std::vector<int64_t> dilation_size    = { 1, 1 };
+    auto *               kernel_size      = aclCreateIntArray(kernel_dims.data(), 2);
+    auto *               strides          = aclCreateIntArray(stride_dims.data(), 2);
+    auto *               paddings_max     = aclCreateIntArray(padding_max_dims.data(), 4);
+    auto *               dilations        = aclCreateIntArray(dilation_size.data(), 2);
 
-    bool ceil_mode = false;
+    bool    ceil_mode = false;
     int64_t auto_pads = 0;
-    GGML_CANN_CALL_ACLNN_OP(ctx, MaxPool, tmp_tensor, kernel_size, strides, auto_pads,
-                    paddings_max, dilations, ceil_mode, acl_dst);
-    ggml_cann_release_resources(ctx, acl_src, acl_dst, tmp_tensor, kernel_size,
-                                strides, paddings_max, dilations);
+    GGML_CANN_CALL_ACLNN_OP(
+        ctx, MaxPool, tmp_tensor, kernel_size, strides, auto_pads, paddings_max, dilations, ceil_mode, acl_dst);
+    ggml_cann_release_resources(ctx, acl_src, acl_dst, tmp_tensor, kernel_size, strides, paddings_max, dilations);
 }
 
-void ggml_cann_pool2d(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    const int32_t* opts = (const int32_t*)dst->op_params;
-    enum ggml_op_pool op = static_cast<ggml_op_pool>(opts[0]);
+void ggml_cann_pool2d(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    const int32_t *   opts = (const int32_t *) dst->op_params;
+    enum ggml_op_pool op   = static_cast<ggml_op_pool>(opts[0]);
     switch (op) {
         case GGML_OP_POOL_AVG:
             ggml_cann_avg_pool2d(ctx, dst);
@@ -745,17 +1077,16 @@ void ggml_cann_pool2d(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param acl_src The source tensor from which data will be copied.
  * @param acl_dst The destination tensor where the data will be copied to.
  */
-static void cann_copy(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                      aclTensor* acl_dst) {
+static void cann_copy(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor * acl_dst) {
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceCopy, acl_dst, acl_src);
 }
 
-void ggml_cann_dup(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];
+void ggml_cann_dup(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0 = dst->src[0];
 
     if (ggml_are_same_shape(src0, dst)) {
-        aclTensor* acl_src = ggml_cann_create_tensor(src0);
-        aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+        aclTensor * acl_src = ggml_cann_create_tensor(src0);
+        aclTensor * acl_dst = ggml_cann_create_tensor(dst);
         if (dst->type == src0->type) {
             cann_copy(ctx, acl_src, acl_dst);
         } else {
@@ -763,22 +1094,23 @@ void ggml_cann_dup(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
         }
         ggml_cann_release_resources(ctx, acl_src, acl_dst);
     } else {
-        void* src_trans_buffer = src0->data;
+        void *               src_trans_buffer = src0->data;
         ggml_cann_pool_alloc src_buffer_allocator;
         if (!ggml_is_contiguous(src0)) {
-            aclTensor* acl_src = ggml_cann_create_tensor(src0);
-            src_buffer_allocator.alloc(ctx.pool(),
-                ggml_nelements(src0) * ggml_type_size(src0->type));
+            aclTensor * acl_src = ggml_cann_create_tensor(src0);
+            src_buffer_allocator.alloc(ctx.pool(), ggml_nelements(src0) * ggml_type_size(src0->type));
             src_trans_buffer = src_buffer_allocator.get();
             size_t src_trans_nb[GGML_MAX_DIMS];
             src_trans_nb[0] = ggml_type_size(src0->type);
             for (int i = 1; i < GGML_MAX_DIMS; i++) {
                 src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
             }
-            aclTensor* src_trans_tensor = ggml_cann_create_tensor(
-                src_trans_buffer, ggml_cann_type_mapping(src0->type),
-                ggml_type_size(src0->type), src0->ne, src_trans_nb,
-                GGML_MAX_DIMS);
+            aclTensor * src_trans_tensor = ggml_cann_create_tensor(src_trans_buffer,
+                                                                   ggml_cann_type_mapping(src0->type),
+                                                                   ggml_type_size(src0->type),
+                                                                   src0->ne,
+                                                                   src_trans_nb,
+                                                                   GGML_MAX_DIMS);
             cann_copy(ctx, acl_src, src_trans_tensor);
             ggml_cann_release_resources(ctx, acl_src, src_trans_tensor);
         }
@@ -789,10 +1121,14 @@ void ggml_cann_dup(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
             src_reshape_nb[i] = src_reshape_nb[i - 1] * dst->ne[i - 1];
         }
 
-        aclTensor* trans_acl_src = ggml_cann_create_tensor(src_trans_buffer,
-            ggml_cann_type_mapping(src0->type),ggml_type_size(src0->type),
-            dst->ne, src_reshape_nb, GGML_MAX_DIMS, ACL_FORMAT_ND);
-        aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+        aclTensor * trans_acl_src = ggml_cann_create_tensor(src_trans_buffer,
+                                                            ggml_cann_type_mapping(src0->type),
+                                                            ggml_type_size(src0->type),
+                                                            dst->ne,
+                                                            src_reshape_nb,
+                                                            GGML_MAX_DIMS,
+                                                            ACL_FORMAT_ND);
+        aclTensor * acl_dst       = ggml_cann_create_tensor(dst);
 
         if (dst->type == src0->type) {
             cann_copy(ctx, trans_acl_src, acl_dst);
@@ -820,17 +1156,20 @@ void ggml_cann_dup(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param type_size The size of each element in the tensor data type.
  * @return An ACL tensor initialized with zeros.
  */
-static aclTensor* aclnn_zero(ggml_backend_cann_context& ctx, void* buffer,
-                             size_t n_bytes, int64_t* ne, int64_t dims,
-                             aclDataType type, size_t type_size) {
+static aclTensor * aclnn_zero(ggml_backend_cann_context & ctx,
+                              void *                      buffer,
+                              size_t                      n_bytes,
+                              int64_t *                   ne,
+                              int64_t                     dims,
+                              aclDataType                 type,
+                              size_t                      type_size) {
     size_t nb[GGML_MAX_DIMS];
     nb[0] = type_size;
     for (int i = 1; i < dims; i++) {
         nb[i] = nb[i - 1] * ne[i - 1];
     }
 
-    aclTensor* zero =
-        ggml_cann_create_tensor(buffer, type, type_size, ne, nb, dims);
+    aclTensor * zero = ggml_cann_create_tensor(buffer, type, type_size, ne, nb, dims);
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceZero, zero);
     return zero;
     GGML_UNUSED(n_bytes);
@@ -854,15 +1193,18 @@ static aclTensor* aclnn_zero(ggml_backend_cann_context& ctx, void* buffer,
  * is 1.0).
  * @return An ACL tensor initialized with value.
  */
-static aclTensor* aclnn_values(ggml_backend_cann_context& ctx, void* buffer,
-                               size_t n_bytes, int64_t* ne, int64_t dims,
-                               aclDataType type, size_t type_size,
-                               float value = 1.0f) {
-    aclTensor* acl_tensor =
-        aclnn_zero(ctx, buffer, n_bytes, ne, dims, type, type_size);
-    float alpha_host = 1.0f;
-    aclScalar* alpha = aclCreateScalar(&alpha_host, aclDataType::ACL_FLOAT);
-    aclScalar* other = aclCreateScalar(&value, aclDataType::ACL_FLOAT);
+static aclTensor * aclnn_values(ggml_backend_cann_context & ctx,
+                                void *                      buffer,
+                                size_t                      n_bytes,
+                                int64_t *                   ne,
+                                int64_t                     dims,
+                                aclDataType                 type,
+                                size_t                      type_size,
+                                float                       value = 1.0f) {
+    aclTensor * acl_tensor = aclnn_zero(ctx, buffer, n_bytes, ne, dims, type, type_size);
+    float       alpha_host = 1.0f;
+    aclScalar * alpha      = aclCreateScalar(&alpha_host, aclDataType::ACL_FLOAT);
+    aclScalar * other      = aclCreateScalar(&value, aclDataType::ACL_FLOAT);
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceAdds, acl_tensor, other, alpha);
     return acl_tensor;
 }
@@ -877,8 +1219,7 @@ static aclTensor* aclnn_values(ggml_backend_cann_context& ctx, void* buffer,
  * @param scalar The scalar value used to fill the tensor.
  * @param acl_dst The destination tensor to be filled with the scalar value.
  */
-static void aclnn_fill_scalar(ggml_backend_cann_context& ctx, float scalar,
-                              aclTensor* acl_dst) {
+static void aclnn_fill_scalar(ggml_backend_cann_context & ctx, float scalar, aclTensor * acl_dst) {
     auto acl_scalar = aclCreateScalar(&scalar, aclDataType::ACL_FLOAT);
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceFillScalar, acl_dst, acl_scalar);
     ggml_cann_release_resources(ctx, acl_scalar);
@@ -906,14 +1247,13 @@ static void aclnn_fill_scalar(ggml_backend_cann_context& ctx, float scalar,
  *                      initialization via memset or arbitrary values via fill_scalar).
  * @return              An aclTensor pointer created from the cached buffer.
  */
-static aclTensor* get_f32_cache_acl_tensor(
-    ggml_backend_cann_context& ctx,
-    void** buffer,
-    int64_t &cache_element,
-    int64_t* ne,
-    size_t* nb,
-    int64_t dims,
-    float value) {
+static aclTensor * get_f32_cache_acl_tensor(ggml_backend_cann_context & ctx,
+                                            void **                     buffer,
+                                            int64_t &                   cache_element,
+                                            int64_t *                   ne,
+                                            size_t *                    nb,
+                                            int64_t                     dims,
+                                            float                       value) {
     // Calculate total number of elements
     int64_t n_element = 1;
     for (int i = 0; i < dims; i++) {
@@ -935,10 +1275,9 @@ static aclTensor* get_f32_cache_acl_tensor(
         if (value == 0.0f) {
             ACL_CHECK(aclrtMemsetAsync(*buffer, size, 0, size, ctx.stream()));
         } else {
-            int64_t pool_ne[1] = { n_element };
-            size_t pool_nb[1] = { sizeof(float) };
-            aclTensor* acl_value = ggml_cann_create_tensor(
-                *buffer, ACL_FLOAT, sizeof(float), pool_ne, pool_nb, 1);
+            int64_t     pool_ne[1] = { n_element };
+            size_t      pool_nb[1] = { sizeof(float) };
+            aclTensor * acl_value  = ggml_cann_create_tensor(*buffer, ACL_FLOAT, sizeof(float), pool_ne, pool_nb, 1);
             aclnn_fill_scalar(ctx, 1, acl_value);
             ggml_cann_release_resources(ctx, acl_value);
         }
@@ -947,11 +1286,11 @@ static aclTensor* get_f32_cache_acl_tensor(
     return ggml_cann_create_tensor(*buffer, ACL_FLOAT, sizeof(float), ne, nb, dims);
 }
 
-void ggml_cann_rms_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_rms_norm(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
     float eps;
     memcpy(&eps, dst->op_params, sizeof(float));
@@ -962,14 +1301,13 @@ void ggml_cann_rms_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         acl_gamma_nb[i] = acl_gamma_nb[i - 1] * src->ne[i - 1];
     }
-    aclTensor* acl_gamma = get_f32_cache_acl_tensor(
-        ctx,
-        &ctx.f32_one_cache,
-        ctx.f32_one_cache_element,
-        src->ne,
-        acl_gamma_nb,
-        1,        // dims
-        1.0f      // value
+    aclTensor * acl_gamma = get_f32_cache_acl_tensor(ctx,
+                                                     &ctx.f32_one_cache,
+                                                     ctx.f32_one_cache_element,
+                                                     src->ne,
+                                                     acl_gamma_nb,
+                                                     1,    // dims
+                                                     1.0f  // value
     );
 
     // build rstd, zero...
@@ -978,14 +1316,13 @@ void ggml_cann_rms_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         acl_rstd_nb[i] = acl_rstd_nb[i - 1] * src->ne[i - 1];
     }
-    aclTensor* acl_rstd = get_f32_cache_acl_tensor(
-        ctx,
-        &ctx.f32_zero_cache,
-        ctx.f32_zero_cache_element,
-        src->ne,
-        acl_rstd_nb,
-        GGML_MAX_DIMS,
-        0.0f      // value
+    aclTensor * acl_rstd = get_f32_cache_acl_tensor(ctx,
+                                                    &ctx.f32_zero_cache,
+                                                    ctx.f32_zero_cache_element,
+                                                    src->ne,
+                                                    acl_rstd_nb,
+                                                    GGML_MAX_DIMS,
+                                                    0.0f  // value
     );
 
     GGML_CANN_CALL_ACLNN_OP(ctx, RmsNorm, acl_src, acl_gamma, eps, acl_dst, acl_rstd);
@@ -993,26 +1330,25 @@ void ggml_cann_rms_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
 }
 
 // TODO: performace is low.
-void ggml_cann_diag_mask(ggml_backend_cann_context& ctx, ggml_tensor* dst,
-                         float value) {
-    ggml_tensor* src = dst->src[0];
+void ggml_cann_diag_mask(ggml_backend_cann_context & ctx, ggml_tensor * dst, float value) {
+    ggml_tensor * src = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
-    const int n_past = ((int32_t*)dst->op_params)[0];
+    const int n_past = ((int32_t *) dst->op_params)[0];
 
     ggml_cann_pool_alloc one_tensor_allocator(ctx.pool(), ggml_nbytes(src));
-    void* buffer = one_tensor_allocator.get();
+    void *               buffer = one_tensor_allocator.get();
 
-    aclTensor* mask_tensor = ggml_cann_create_tensor(buffer, ggml_cann_type_mapping(src->type),
-        ggml_type_size(src->type), src->ne, src->nb, GGML_MAX_DIMS);
+    aclTensor * mask_tensor = ggml_cann_create_tensor(
+        buffer, ggml_cann_type_mapping(src->type), ggml_type_size(src->type), src->ne, src->nb, GGML_MAX_DIMS);
 
     aclnn_fill_scalar(ctx, value, mask_tensor);
 
-    aclScalar* alpha = nullptr;
-    float alphaValue = 1.0f;
-    alpha = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
+    aclScalar * alpha      = nullptr;
+    float       alphaValue = 1.0f;
+    alpha                  = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceTriu, mask_tensor, n_past + 1);
     GGML_CANN_CALL_ACLNN_OP(ctx, Tril, acl_src, n_past + 1, acl_dst);
@@ -1035,25 +1371,27 @@ void ggml_cann_diag_mask(ggml_backend_cann_context& ctx, ggml_tensor* dst,
  * tensor.
  * @param dims The number of dimensions in the tensor.
  */
-static void aclnn_permute(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                          aclTensor* acl_dst, int64_t* new_dim, uint64_t dims) {
-    aclIntArray* acl_dims = aclCreateIntArray(new_dim, dims);
+static void aclnn_permute(ggml_backend_cann_context & ctx,
+                          aclTensor *                 acl_src,
+                          aclTensor *                 acl_dst,
+                          int64_t *                   new_dim,
+                          uint64_t                    dims) {
+    aclIntArray * acl_dims = aclCreateIntArray(new_dim, dims);
     GGML_CANN_CALL_ACLNN_OP(ctx, Permute, acl_src, acl_dims, acl_dst);
     ggml_cann_release_resources(ctx, acl_dims);
 }
 
-static void ggml_cann_im2col_2d_post_process(ggml_backend_cann_context& ctx,
-                                             ggml_tensor* dst,
-                                             ggml_tensor* src1,
-                                             aclTensor* tmp_cast_tensor,
-                                             aclTensor* tmp_im2col_tensor) {
+static void ggml_cann_im2col_2d_post_process(ggml_backend_cann_context & ctx,
+                                             ggml_tensor *               dst,
+                                             ggml_tensor *               src1,
+                                             aclTensor *                 tmp_cast_tensor,
+                                             aclTensor *                 tmp_im2col_tensor) {
     // Permute: [N, IC * KH * KW, OW * OH] -> [N, OW * OH, IC * KH * KW]
-    int64_t dst_ne[] = {dst->ne[0], dst->ne[1] * dst->ne[2], dst->ne[3]};
-    size_t dst_nb[] = {dst->nb[0], dst->nb[1], dst->nb[3]};
-    aclTensor* acl_dst =
-        ggml_cann_create_tensor(dst, dst_ne, dst_nb, GGML_MAX_DIMS - 1);
+    int64_t     dst_ne[] = { dst->ne[0], dst->ne[1] * dst->ne[2], dst->ne[3] };
+    size_t      dst_nb[] = { dst->nb[0], dst->nb[1], dst->nb[3] };
+    aclTensor * acl_dst  = ggml_cann_create_tensor(dst, dst_ne, dst_nb, GGML_MAX_DIMS - 1);
 
-    int64_t permute_dim[] = {0, 2, 1};
+    int64_t permute_dim[] = { 0, 2, 1 };
     if (src1->type != dst->type) {
         aclnn_permute(ctx, tmp_cast_tensor, acl_dst, permute_dim, 3);
     } else {
@@ -1063,101 +1401,99 @@ static void ggml_cann_im2col_2d_post_process(ggml_backend_cann_context& ctx,
     ggml_cann_release_resources(ctx, acl_dst);
 }
 
-static void ggml_cann_im2col_1d_post_process(
-    ggml_backend_cann_context& ctx, ggml_tensor* dst, ggml_tensor* src1,
-    aclTensor* tmp_cast_tensor, aclTensor* tmp_im2col_tensor,
-    const std::vector<int64_t>& im2col_op_params) {
+static void ggml_cann_im2col_1d_post_process(ggml_backend_cann_context &  ctx,
+                                             ggml_tensor *                dst,
+                                             ggml_tensor *                src1,
+                                             aclTensor *                  tmp_cast_tensor,
+                                             aclTensor *                  tmp_im2col_tensor,
+                                             const std::vector<int64_t> & im2col_op_params) {
     // get params
-    const int64_t KH = im2col_op_params[0];
-    const int64_t KW = im2col_op_params[1];
-    const int64_t IW = im2col_op_params[2];
-    const int64_t IC = im2col_op_params[3];
-    const int64_t N = im2col_op_params[4];
-    const int64_t OH = im2col_op_params[5];
-    const int64_t OW = im2col_op_params[6];
-    const int64_t s0 = im2col_op_params[7];
-    const int64_t p0 = im2col_op_params[8];
-    const int64_t d0 = im2col_op_params[9];
+    const int64_t KH             = im2col_op_params[0];
+    const int64_t KW             = im2col_op_params[1];
+    const int64_t IW             = im2col_op_params[2];
+    const int64_t IC             = im2col_op_params[3];
+    const int64_t N              = im2col_op_params[4];
+    const int64_t OH             = im2col_op_params[5];
+    const int64_t OW             = im2col_op_params[6];
+    const int64_t s0             = im2col_op_params[7];
+    const int64_t p0             = im2col_op_params[8];
+    const int64_t d0             = im2col_op_params[9];
     const int64_t n_bytes_factor = im2col_op_params[10];
 
     // Permute: [N, IC * KH * KW, OW * OH] ->
     // [N, OW * OH * n_bytes_factor, IC * KH * KW]
     ggml_cann_pool_alloc tmp_permute_allocator(ctx.pool());
     tmp_permute_allocator.alloc(ggml_nbytes(dst) * n_bytes_factor);
-    void* tmp_permute_buffer = tmp_permute_allocator.get();
+    void * tmp_permute_buffer = tmp_permute_allocator.get();
 
-    int64_t tmp_permute_ne[] = {IC * KH * KW, OW * OH * n_bytes_factor, N};
-    size_t tmp_permute_nb[GGML_MAX_DIMS - 1];
+    int64_t tmp_permute_ne[] = { IC * KH * KW, OW * OH * n_bytes_factor, N };
+    size_t  tmp_permute_nb[GGML_MAX_DIMS - 1];
     tmp_permute_nb[0] = ggml_type_size(dst->type);
     for (int i = 1; i < GGML_MAX_DIMS - 1; i++) {
         tmp_permute_nb[i] = tmp_permute_nb[i - 1] * tmp_permute_ne[i - 1];
     }
 
-    aclTensor* tmp_permute_tensor = ggml_cann_create_tensor(
-        tmp_permute_buffer, ggml_cann_type_mapping(dst->type),
-        ggml_type_size(dst->type), tmp_permute_ne, tmp_permute_nb,
-        GGML_MAX_DIMS - 1, ACL_FORMAT_ND);
+    aclTensor * tmp_permute_tensor = ggml_cann_create_tensor(tmp_permute_buffer,
+                                                             ggml_cann_type_mapping(dst->type),
+                                                             ggml_type_size(dst->type),
+                                                             tmp_permute_ne,
+                                                             tmp_permute_nb,
+                                                             GGML_MAX_DIMS - 1,
+                                                             ACL_FORMAT_ND);
 
-    int64_t permute_dim[] = {0, 2, 1};
+    int64_t permute_dim[] = { 0, 2, 1 };
     if (src1->type != dst->type) {
         aclnn_permute(ctx, tmp_cast_tensor, tmp_permute_tensor, permute_dim, 3);
     } else {
-        aclnn_permute(ctx, tmp_im2col_tensor, tmp_permute_tensor, permute_dim,
-                      3);
+        aclnn_permute(ctx, tmp_im2col_tensor, tmp_permute_tensor, permute_dim, 3);
     }
 
     // number of times the kernel moves in W dimension
     const int n_step_w = (IW + 2 * p0 - d0 * (KW - 1) - 1) / s0 + 1;
-    size_t offset;
-    void *cur_dst_buffer = dst->data, *cur_permute_buffer = tmp_permute_buffer;
+    size_t    offset;
+    void *    cur_dst_buffer = dst->data, *cur_permute_buffer = tmp_permute_buffer;
 
     // memory copy with offset to restore 1D im2col from 2d
     if (IC > 1) {
-        offset = IC * KH * KW * n_step_w * ggml_type_size(dst->type);
+        offset          = IC * KH * KW * n_step_w * ggml_type_size(dst->type);
         size_t size_cpy = KH * KW * ggml_type_size(dst->type);
 
         for (int c = 0; c < IC; c++) {
-            cur_permute_buffer = (char*)tmp_permute_buffer + offset +
-                                 KH * KW * c * ggml_type_size(dst->type);
-            cur_dst_buffer = (char*)dst->data +
-                             c * KH * KW * n_step_w * ggml_type_size(dst->type);
+            cur_permute_buffer = (char *) tmp_permute_buffer + offset + KH * KW * c * ggml_type_size(dst->type);
+            cur_dst_buffer     = (char *) dst->data + c * KH * KW * n_step_w * ggml_type_size(dst->type);
 
             for (int i = 0; i < n_step_w; i++) {
-                ggml_cann_async_memcpy(ctx, cur_dst_buffer, cur_permute_buffer, size_cpy,
-                    ACL_MEMCPY_DEVICE_TO_DEVICE);
-                cur_dst_buffer =
-                    (char*)cur_dst_buffer + KH * KW * ggml_type_size(dst->type);
-                cur_permute_buffer = (char*)cur_permute_buffer +
-                                     KH * KW * IC * ggml_type_size(dst->type);
+                ggml_cann_async_memcpy(ctx, cur_dst_buffer, cur_permute_buffer, size_cpy, ACL_MEMCPY_DEVICE_TO_DEVICE);
+                cur_dst_buffer     = (char *) cur_dst_buffer + KH * KW * ggml_type_size(dst->type);
+                cur_permute_buffer = (char *) cur_permute_buffer + KH * KW * IC * ggml_type_size(dst->type);
             }
         }
     } else {
-        offset = KH * KW * n_step_w *
-                 ggml_type_size(dst->type);  // equal to ggml_nbytes(dst)
-        ggml_cann_async_memcpy(ctx, dst->data, (char*)tmp_permute_buffer + offset, offset,
-            ACL_MEMCPY_DEVICE_TO_DEVICE);
+        offset = KH * KW * n_step_w * ggml_type_size(dst->type);  // equal to ggml_nbytes(dst)
+        ggml_cann_async_memcpy(
+            ctx, dst->data, (char *) tmp_permute_buffer + offset, offset, ACL_MEMCPY_DEVICE_TO_DEVICE);
     }
 
     ggml_cann_release_resources(ctx, tmp_permute_tensor);
 }
 
-void ggml_cann_im2col(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];  // kernel
-    ggml_tensor* src1 = dst->src[1];  // input
+void ggml_cann_im2col(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0 = dst->src[0];  // kernel
+    ggml_tensor * src1 = dst->src[1];  // input
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
     // aclnnIm2col only works on 2D. set s1, p1, d1 to 1 to perform 2D
     // im2col and do post-processing to restore it to 1D.
-    const bool is_2D = ((const int32_t*)(dst->op_params))[6] == 1;
-    const int32_t s0 = ((const int32_t*)(dst->op_params))[0];
-    const int32_t s1 = is_2D ? ((const int32_t*)(dst->op_params))[1] : 1;
-    const int32_t p0 = ((const int32_t*)(dst->op_params))[2];
-    const int32_t p1 = is_2D ? ((const int32_t*)(dst->op_params))[3] : 1;
-    const int32_t d0 = ((const int32_t*)(dst->op_params))[4];
-    const int32_t d1 = is_2D ? ((const int32_t*)(dst->op_params))[5] : 1;
+    const bool    is_2D = ((const int32_t *) (dst->op_params))[6] == 1;
+    const int32_t s0    = ((const int32_t *) (dst->op_params))[0];
+    const int32_t s1    = is_2D ? ((const int32_t *) (dst->op_params))[1] : 1;
+    const int32_t p0    = ((const int32_t *) (dst->op_params))[2];
+    const int32_t p1    = is_2D ? ((const int32_t *) (dst->op_params))[3] : 1;
+    const int32_t d0    = ((const int32_t *) (dst->op_params))[4];
+    const int32_t d1    = is_2D ? ((const int32_t *) (dst->op_params))[5] : 1;
 
-    const int64_t N = ne13;
+    const int64_t N  = ne13;
     const int64_t IC = ne12;
     const int64_t KH = ne01;
     const int64_t KW = ne00;
@@ -1170,9 +1506,9 @@ void ggml_cann_im2col(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     const int64_t n_bytes_factor = is_2D ? 1 : 3;
 
     // im2col: [N,C,H,W] -> [N, IC * KH * KW, OW * OH * n_bytes_factor]
-    aclTensor* acl_src1 = ggml_cann_create_tensor(src1);
-    int64_t tmp_im2col_ne[] = {OW * OH * n_bytes_factor, IC * KH * KW, N};
-    size_t tmp_im2col_nb[GGML_MAX_DIMS - 1];
+    aclTensor * acl_src1        = ggml_cann_create_tensor(src1);
+    int64_t     tmp_im2col_ne[] = { OW * OH * n_bytes_factor, IC * KH * KW, N };
+    size_t      tmp_im2col_nb[GGML_MAX_DIMS - 1];
 
     tmp_im2col_nb[0] = ggml_type_size(src1->type);
     for (int i = 1; i < GGML_MAX_DIMS - 1; i++) {
@@ -1182,31 +1518,31 @@ void ggml_cann_im2col(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     // Calculate im2col.
     // If dst is f16, tmp_buffer is f32, we need alloc src.typesize *
     // dst.elemcount.
-    ggml_cann_pool_alloc im2col_allocator(
-        ctx.pool(),
-        ggml_nelements(dst) * ggml_element_size(src1) * n_bytes_factor);
-    void* tmp_im2col_buffer = im2col_allocator.get();
+    ggml_cann_pool_alloc im2col_allocator(ctx.pool(), ggml_nelements(dst) * ggml_element_size(src1) * n_bytes_factor);
+    void *               tmp_im2col_buffer = im2col_allocator.get();
 
-    aclTensor* tmp_im2col_tensor = ggml_cann_create_tensor(
-        tmp_im2col_buffer, ggml_cann_type_mapping(src1->type),
-        ggml_type_size(src1->type), tmp_im2col_ne, tmp_im2col_nb,
-        GGML_MAX_DIMS - 1, ACL_FORMAT_ND);
+    aclTensor * tmp_im2col_tensor = ggml_cann_create_tensor(tmp_im2col_buffer,
+                                                            ggml_cann_type_mapping(src1->type),
+                                                            ggml_type_size(src1->type),
+                                                            tmp_im2col_ne,
+                                                            tmp_im2col_nb,
+                                                            GGML_MAX_DIMS - 1,
+                                                            ACL_FORMAT_ND);
 
-    std::vector<int64_t> kernel_dims = {KH, KW};
-    std::vector<int64_t> dilation_size = {d1, d0};
-    std::vector<int64_t> padding_dims = {p1, p0};
-    std::vector<int64_t> stride_dims = {s1, s0};
-    auto* kernel_size = aclCreateIntArray(kernel_dims.data(), 2);
-    auto* dilations = aclCreateIntArray(dilation_size.data(), 2);
-    auto* paddings = aclCreateIntArray(padding_dims.data(), 2);
-    auto* strides = aclCreateIntArray(stride_dims.data(), 2);
-    GGML_CANN_CALL_ACLNN_OP(ctx, Im2col, acl_src1, kernel_size, dilations,
-                    paddings, strides, tmp_im2col_tensor);
+    std::vector<int64_t> kernel_dims   = { KH, KW };
+    std::vector<int64_t> dilation_size = { d1, d0 };
+    std::vector<int64_t> padding_dims  = { p1, p0 };
+    std::vector<int64_t> stride_dims   = { s1, s0 };
+    auto *               kernel_size   = aclCreateIntArray(kernel_dims.data(), 2);
+    auto *               dilations     = aclCreateIntArray(dilation_size.data(), 2);
+    auto *               paddings      = aclCreateIntArray(padding_dims.data(), 2);
+    auto *               strides       = aclCreateIntArray(stride_dims.data(), 2);
+    GGML_CANN_CALL_ACLNN_OP(ctx, Im2col, acl_src1, kernel_size, dilations, paddings, strides, tmp_im2col_tensor);
 
     // Cast if dst is f16.
-    aclTensor* tmp_cast_tensor = nullptr;
+    aclTensor *          tmp_cast_tensor = nullptr;
     ggml_cann_pool_alloc tmp_cast_allocator(ctx.pool());
-    void* tmp_cast_buffer = nullptr;
+    void *               tmp_cast_buffer = nullptr;
     if (src1->type != dst->type) {
         tmp_cast_allocator.alloc(ggml_nbytes(dst) * n_bytes_factor);
         tmp_cast_buffer = tmp_cast_allocator.get();
@@ -1216,26 +1552,26 @@ void ggml_cann_im2col(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
             temp_cast_nb[i] = temp_cast_nb[i - 1] * tmp_im2col_ne[i - 1];
         }
 
-        tmp_cast_tensor = ggml_cann_create_tensor(
-            tmp_cast_buffer, ggml_cann_type_mapping(dst->type),
-            ggml_type_size(dst->type), tmp_im2col_ne, temp_cast_nb,
-            GGML_MAX_DIMS - 1, ACL_FORMAT_ND);
+        tmp_cast_tensor = ggml_cann_create_tensor(tmp_cast_buffer,
+                                                  ggml_cann_type_mapping(dst->type),
+                                                  ggml_type_size(dst->type),
+                                                  tmp_im2col_ne,
+                                                  temp_cast_nb,
+                                                  GGML_MAX_DIMS - 1,
+                                                  ACL_FORMAT_ND);
         aclnn_cast(ctx, tmp_im2col_tensor, tmp_cast_tensor, ggml_cann_type_mapping(dst->type));
     }
 
     // post-processing
     if (is_2D) {
-        ggml_cann_im2col_2d_post_process(ctx, dst, src1, tmp_cast_tensor,
-                                         tmp_im2col_tensor);
+        ggml_cann_im2col_2d_post_process(ctx, dst, src1, tmp_cast_tensor, tmp_im2col_tensor);
     } else {
-        std::vector<int64_t> im2col_op_params = {
-            KH, KW, IW, IC, N, OH, OW, s0, p0, d0, n_bytes_factor};
-        ggml_cann_im2col_1d_post_process(ctx, dst, src1, tmp_cast_tensor,
-                                         tmp_im2col_tensor, im2col_op_params);
+        std::vector<int64_t> im2col_op_params = { KH, KW, IW, IC, N, OH, OW, s0, p0, d0, n_bytes_factor };
+        ggml_cann_im2col_1d_post_process(ctx, dst, src1, tmp_cast_tensor, tmp_im2col_tensor, im2col_op_params);
     }
 
-    ggml_cann_release_resources(ctx, acl_src1, tmp_im2col_tensor, tmp_cast_tensor,
-        kernel_size, dilations, paddings, strides);
+    ggml_cann_release_resources(
+        ctx, acl_src1, tmp_im2col_tensor, tmp_cast_tensor, kernel_size, dilations, paddings, strides);
 }
 
 /**
@@ -1251,136 +1587,143 @@ void ggml_cann_im2col(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param ctx The context for the CANN backend operations.
  * @param acl_src The tensor on which the exponential function will be applied.
  */
-static void aclnn_exp(ggml_backend_cann_context& ctx, aclTensor* acl_src) {
+static void aclnn_exp(ggml_backend_cann_context & ctx, aclTensor * acl_src) {
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceExp, acl_src);
 }
 
-void aclnn_cos(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                      aclTensor* acl_dst) {
-    if(acl_dst == nullptr) {
+void aclnn_cos(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor * acl_dst) {
+    if (acl_dst == nullptr) {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceCos, acl_src);
     } else {
         GGML_CANN_CALL_ACLNN_OP(ctx, Cos, acl_src, acl_dst);
     }
 }
 
-void aclnn_sin(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                      aclTensor* acl_dst) {
-    if(acl_dst == nullptr) {
+void aclnn_sin(ggml_backend_cann_context & ctx, aclTensor * acl_src, aclTensor * acl_dst) {
+    if (acl_dst == nullptr) {
         GGML_CANN_CALL_ACLNN_OP(ctx, InplaceSin, acl_src);
     } else {
         GGML_CANN_CALL_ACLNN_OP(ctx, Sin, acl_src, acl_dst);
     }
 }
 
-void ggml_cann_timestep_embedding(ggml_backend_cann_context& ctx,
-                                  ggml_tensor* dst) {
-    const ggml_tensor* src = dst->src[0];
+void ggml_cann_timestep_embedding(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src = dst->src[0];
 
     GGML_ASSERT(src->type == GGML_TYPE_F32);
     GGML_ASSERT(dst->type == GGML_TYPE_F32);
 
-    const int dim = dst->op_params[0];
+    const int dim        = dst->op_params[0];
     const int max_period = dst->op_params[1];
-    int half = dim / 2;
+    int       half       = dim / 2;
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src);
+    aclTensor * acl_src = ggml_cann_create_tensor(src);
 
     // arange: [0, ..., half)
-    float start = 0;
-    float stop = half;
-    float step = 1;
+    float   start             = 0;
+    float   stop              = half;
+    float   step              = 1;
     int64_t n_elements_arange = half;
-    int64_t tmp_arange_ne[] = {half};
-    size_t tmp_arange_nb[] = {sizeof(dst->type)};
+    int64_t tmp_arange_ne[]   = { half };
+    size_t  tmp_arange_nb[]   = { sizeof(dst->type) };
 
     ggml_cann_pool_alloc arange_allocator(ctx.pool(), half * sizeof(dst->type));
-    void* tmp_arange_buffer = arange_allocator.get();
-    aclTensor* tmp_arange_tensor = ggml_cann_create_tensor(
-        tmp_arange_buffer, ggml_cann_type_mapping(dst->type),
-        ggml_type_size(dst->type), tmp_arange_ne, tmp_arange_nb,
-        GGML_MAX_DIMS - 3, ACL_FORMAT_ND);
+    void *               tmp_arange_buffer = arange_allocator.get();
+    aclTensor *          tmp_arange_tensor = ggml_cann_create_tensor(tmp_arange_buffer,
+                                                            ggml_cann_type_mapping(dst->type),
+                                                            ggml_type_size(dst->type),
+                                                            tmp_arange_ne,
+                                                            tmp_arange_nb,
+                                                            GGML_MAX_DIMS - 3,
+                                                            ACL_FORMAT_ND);
 
     aclnn_arange(ctx, tmp_arange_tensor, start, stop, step, n_elements_arange);
 
     // freq
     float freq_param = -logf(max_period) / half;
-    bool inplace = true;
+    bool  inplace    = true;
     aclnn_muls(ctx, tmp_arange_tensor, freq_param, nullptr, inplace);
     aclnn_exp(ctx, tmp_arange_tensor);
 
     // permute: src [0,1,2,3]->[0,1,3,2]
-    int64_t tmp_permute_ne[] = {src->ne[1], src->ne[0], src->ne[2], src->ne[3]};
-    size_t tmp_permute_nb[GGML_MAX_DIMS];
+    int64_t tmp_permute_ne[] = { src->ne[1], src->ne[0], src->ne[2], src->ne[3] };
+    size_t  tmp_permute_nb[GGML_MAX_DIMS];
     tmp_permute_nb[0] = ggml_type_size(src->type);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         tmp_permute_nb[i] = tmp_permute_nb[i - 1] * tmp_permute_ne[i - 1];
     }
 
     ggml_cann_pool_alloc permute_allocator(ctx.pool(), ggml_nbytes(src));
-    void* tmp_permute_buffer = permute_allocator.get();
-    aclTensor* tmp_permute_tensor = ggml_cann_create_tensor(
-        tmp_permute_buffer, ggml_cann_type_mapping(src->type),
-        ggml_type_size(src->type), tmp_permute_ne, tmp_permute_nb,
-        GGML_MAX_DIMS, ACL_FORMAT_ND);
-    int64_t permute_dim[] = {0, 1, 3, 2};
-    int64_t num_dims = 4;
+    void *               tmp_permute_buffer = permute_allocator.get();
+    aclTensor *          tmp_permute_tensor = ggml_cann_create_tensor(tmp_permute_buffer,
+                                                             ggml_cann_type_mapping(src->type),
+                                                             ggml_type_size(src->type),
+                                                             tmp_permute_ne,
+                                                             tmp_permute_nb,
+                                                             GGML_MAX_DIMS,
+                                                             ACL_FORMAT_ND);
+    int64_t              permute_dim[]      = { 0, 1, 3, 2 };
+    int64_t              num_dims           = 4;
     aclnn_permute(ctx, acl_src, tmp_permute_tensor, permute_dim, num_dims);
 
     // timestep * freq
-    int64_t tmp_mul_ne[] = {src->ne[1] * half, src->ne[0], src->ne[2],
-                            src->ne[3]};
-    size_t tmp_mul_nb[GGML_MAX_DIMS];
+    int64_t tmp_mul_ne[] = { src->ne[1] * half, src->ne[0], src->ne[2], src->ne[3] };
+    size_t  tmp_mul_nb[GGML_MAX_DIMS];
     tmp_mul_nb[0] = ggml_type_size(src->type);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         tmp_mul_nb[i] = tmp_mul_nb[i - 1] * tmp_mul_ne[i - 1];
     }
 
-    int mul_nelements =
-        src->ne[1] * half * src->ne[0] * src->ne[2] * src->ne[3];
+    int mul_nelements = src->ne[1] * half * src->ne[0] * src->ne[2] * src->ne[3];
 
-    ggml_cann_pool_alloc mul_allocator(
-        ctx.pool(), mul_nelements * ggml_type_size(src->type));
-    void* tmp_mul_buffer = mul_allocator.get();
-    aclTensor* tmp_mul_tensor = ggml_cann_create_tensor(
-        tmp_mul_buffer, ggml_cann_type_mapping(src->type),
-        ggml_type_size(src->type), tmp_mul_ne, tmp_mul_nb, GGML_MAX_DIMS,
-        ACL_FORMAT_ND);
+    ggml_cann_pool_alloc mul_allocator(ctx.pool(), mul_nelements * ggml_type_size(src->type));
+    void *               tmp_mul_buffer = mul_allocator.get();
+    aclTensor *          tmp_mul_tensor = ggml_cann_create_tensor(tmp_mul_buffer,
+                                                         ggml_cann_type_mapping(src->type),
+                                                         ggml_type_size(src->type),
+                                                         tmp_mul_ne,
+                                                         tmp_mul_nb,
+                                                         GGML_MAX_DIMS,
+                                                         ACL_FORMAT_ND);
     aclnn_mul(ctx, tmp_permute_tensor, tmp_arange_tensor, tmp_mul_tensor);
 
     // cos
-    ggml_cann_pool_alloc cos_allocator(
-        ctx.pool(), mul_nelements * ggml_type_size(src->type));
-    void* tmp_cos_buffer = cos_allocator.get();
-    aclTensor* tmp_cos_tensor = ggml_cann_create_tensor(
-        tmp_cos_buffer, ggml_cann_type_mapping(dst->type),
-        ggml_type_size(dst->type), tmp_mul_ne, tmp_mul_nb, GGML_MAX_DIMS,
-        ACL_FORMAT_ND);
+    ggml_cann_pool_alloc cos_allocator(ctx.pool(), mul_nelements * ggml_type_size(src->type));
+    void *               tmp_cos_buffer = cos_allocator.get();
+    aclTensor *          tmp_cos_tensor = ggml_cann_create_tensor(tmp_cos_buffer,
+                                                         ggml_cann_type_mapping(dst->type),
+                                                         ggml_type_size(dst->type),
+                                                         tmp_mul_ne,
+                                                         tmp_mul_nb,
+                                                         GGML_MAX_DIMS,
+                                                         ACL_FORMAT_ND);
 
     aclnn_cos(ctx, tmp_mul_tensor, tmp_cos_tensor);
 
     // sin
-    ggml_cann_pool_alloc sin_allocator(
-        ctx.pool(), mul_nelements * ggml_type_size(src->type));
-    void* tmp_sin_buffer = sin_allocator.get();
-    aclTensor* tmp_sin_tensor = ggml_cann_create_tensor(
-        tmp_sin_buffer, ggml_cann_type_mapping(dst->type),
-        ggml_type_size(dst->type), tmp_mul_ne, tmp_mul_nb, GGML_MAX_DIMS,
-        ACL_FORMAT_ND);
+    ggml_cann_pool_alloc sin_allocator(ctx.pool(), mul_nelements * ggml_type_size(src->type));
+    void *               tmp_sin_buffer = sin_allocator.get();
+    aclTensor *          tmp_sin_tensor = ggml_cann_create_tensor(tmp_sin_buffer,
+                                                         ggml_cann_type_mapping(dst->type),
+                                                         ggml_type_size(dst->type),
+                                                         tmp_mul_ne,
+                                                         tmp_mul_nb,
+                                                         GGML_MAX_DIMS,
+                                                         ACL_FORMAT_ND);
 
     aclnn_sin(ctx, tmp_mul_tensor, tmp_sin_tensor);
 
     // concat
-    int64_t concat_dim = 3;
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
-    aclTensor* tensors[] = {tmp_cos_tensor, tmp_sin_tensor};
-    aclTensorList* tensor_list = aclCreateTensorList(tensors, 2);
+    int64_t         concat_dim  = 3;
+    aclTensor *     acl_dst     = ggml_cann_create_tensor(dst);
+    aclTensor *     tensors[]   = { tmp_cos_tensor, tmp_sin_tensor };
+    aclTensorList * tensor_list = aclCreateTensorList(tensors, 2);
     aclnn_concat(ctx, tensor_list, acl_dst, concat_dim);
 
     // release
     // segmentation fault when delete both tensorList and his elements.
-    ggml_cann_release_resources(ctx, tensor_list, acl_src, tmp_arange_tensor,
-        tmp_permute_tensor, tmp_mul_tensor, acl_dst);
+    ggml_cann_release_resources(
+        ctx, tensor_list, acl_src, tmp_arange_tensor, tmp_permute_tensor, tmp_mul_tensor, acl_dst);
 }
 
 /**
@@ -1399,8 +1742,7 @@ void ggml_cann_timestep_embedding(ggml_backend_cann_context& ctx,
  * @param acl_exp The exponent tensor, each element of which is used to raise
  * the corresponding element in the destination tensor.
  */
-static void aclnn_pow_tensor_tensor(ggml_backend_cann_context& ctx,
-                                    aclTensor* acl_dst, aclTensor* acl_exp) {
+static void aclnn_pow_tensor_tensor(ggml_backend_cann_context & ctx, aclTensor * acl_dst, aclTensor * acl_exp) {
     GGML_CANN_CALL_ACLNN_OP(ctx, InplacePowTensorTensor, acl_dst, acl_exp);
 }
 
@@ -1424,22 +1766,25 @@ static void aclnn_pow_tensor_tensor(ggml_backend_cann_context& ctx,
  * @param stop          Stopping exponent offset (exclusive).
  * @param step          Step size for the exponent increment.
  */
-static void aclnn_get_slope_inner(ggml_backend_cann_context& ctx, void* slope_buffer,
-    float m, int64_t size, float start, float stop, float step){
-    int64_t ne[] = {size};
-    size_t nb[] = {sizeof(float)};
+static void aclnn_get_slope_inner(ggml_backend_cann_context & ctx,
+                                  void *                      slope_buffer,
+                                  float                       m,
+                                  int64_t                     size,
+                                  float                       start,
+                                  float                       stop,
+                                  float                       step) {
+    int64_t ne[] = { size };
+    size_t  nb[] = { sizeof(float) };
 
     ggml_cann_pool_alloc arange_allocator(ctx.pool(), size * sizeof(float));
-    void* arange_buffer = arange_allocator.get();
+    void *               arange_buffer = arange_allocator.get();
 
-    aclTensor* arange_tensor = ggml_cann_create_tensor(
-        arange_buffer, ACL_FLOAT, sizeof(float), ne, nb, 1);
+    aclTensor * arange_tensor = ggml_cann_create_tensor(arange_buffer, ACL_FLOAT, sizeof(float), ne, nb, 1);
     aclnn_arange(ctx, arange_tensor, start, stop, step, size);
 
-    aclTensor* slope_tensor = ggml_cann_create_tensor(
-        slope_buffer, ACL_FLOAT, sizeof(float), ne, nb, 1);
+    aclTensor * slope_tensor = ggml_cann_create_tensor(slope_buffer, ACL_FLOAT, sizeof(float), ne, nb, 1);
 
-    aclScalar* sc = aclCreateScalar(&m, aclDataType::ACL_FLOAT);
+    aclScalar * sc = aclCreateScalar(&m, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, PowScalarTensor, sc, arange_tensor, slope_tensor);
     ggml_cann_release_resources(ctx, sc, arange_tensor, slope_tensor);
@@ -1470,8 +1815,7 @@ static void aclnn_get_slope_inner(ggml_backend_cann_context& ctx, void* slope_bu
  * @param max_bias      Maximum bias value for slope computation.
  *
 */
-static void aclnn_get_slope(ggml_backend_cann_context & ctx, int64_t n_head,
-    void* slope_buffer, float max_bias) {
+static void aclnn_get_slope(ggml_backend_cann_context & ctx, int64_t n_head, void * slope_buffer, float max_bias) {
     const int n_head_log2 = 1u << (uint32_t) floor(log2(n_head));
 
     float m0 = powf(2.0f, -(max_bias) / n_head_log2);
@@ -1496,8 +1840,7 @@ static void aclnn_get_slope(ggml_backend_cann_context & ctx, int64_t n_head,
         step  = 2;
         count = n_head - n_head_log2;
         aclnn_get_slope_inner(
-            ctx, (char *) slope_buffer + n_head_log2 * sizeof(float),
-            m1, count, start, end + 1, step);
+            ctx, (char *) slope_buffer + n_head_log2 * sizeof(float), m1, count, start, end + 1, step);
     }
 }
 
@@ -1522,17 +1865,19 @@ static void aclnn_get_slope(ggml_backend_cann_context & ctx, int64_t n_head,
  * - Write data into dst_ptr using only the shape information of the dst tensor.
  * - `GGML_MAX_DIMS + 2` is used to extend tensor dimensions for broadcasting.
  */
-static void aclnn_add_alibi(ggml_backend_cann_context& ctx, ggml_tensor* mask,
-    ggml_tensor* dst, void* dst_ptr, float max_bias) {
-    void* slope_buffer = nullptr;
-    void* bias_buffer = nullptr;
+static void aclnn_add_alibi(ggml_backend_cann_context & ctx,
+                            ggml_tensor *               mask,
+                            ggml_tensor *               dst,
+                            void *                      dst_ptr,
+                            float                       max_bias) {
+    void * slope_buffer = nullptr;
+    void * bias_buffer  = nullptr;
 
     if (max_bias > 0.0f) {
-        int64_t n_heads = dst->ne[2];
+        int64_t              n_heads = dst->ne[2];
         ggml_cann_pool_alloc slope_allocator(ctx.pool(), n_heads * sizeof(float));
         slope_buffer = slope_allocator.get();
-        ggml_cann_pool_alloc bias_allocator(
-                    ctx.pool(), ggml_nelements(dst) * ggml_element_size(dst));
+        ggml_cann_pool_alloc bias_allocator(ctx.pool(), ggml_nelements(dst) * ggml_element_size(dst));
         bias_buffer = bias_allocator.get();
         aclnn_get_slope(ctx, n_heads, slope_buffer, max_bias);
     }
@@ -1543,16 +1888,12 @@ static void aclnn_add_alibi(ggml_backend_cann_context& ctx, ggml_tensor* mask,
 
     // broadcast the mask across rows
     int64_t mask_ne[] = { mask->ne[0], dst->ne[1], mask->ne[2], 1, mask->ne[3], 1 };
-    size_t  mask_nb[] = {
-        mask_nb[0] = mask->nb[0], mask_nb[1] = mask->nb[1], mask_nb[2] = mask->nb[2],
-        mask_nb[3] = mask->nb[2], mask_nb[4] = mask->nb[3], mask_nb[5] = mask->nb[3]
-    };
+    size_t  mask_nb[] = { mask_nb[0] = mask->nb[0], mask_nb[1] = mask->nb[1], mask_nb[2] = mask->nb[2],
+                          mask_nb[3] = mask->nb[2], mask_nb[4] = mask->nb[3], mask_nb[5] = mask->nb[3] };
 
     int64_t dst_ne[] = { dst->ne[0], dst->ne[1], mask->ne[2], nr2, mask->ne[3], nr3 };
-    size_t  dst_nb[] = {
-        dst_nb[0] = dst->nb[0], dst_nb[1] = dst->nb[1], dst_nb[2] = dst->nb[2],
-        dst_nb[3] = dst->nb[2], dst_nb[4] = dst->nb[3], dst_nb[5] = dst->nb[3]
-    };
+    size_t  dst_nb[] = { dst_nb[0] = dst->nb[0], dst_nb[1] = dst->nb[1], dst_nb[2] = dst->nb[2],
+                         dst_nb[3] = dst->nb[2], dst_nb[4] = dst->nb[3], dst_nb[5] = dst->nb[3] };
 
     // slope is a 1 dim tensor, slope.ne2 == dst.ne2
     int64_t slope_ne[] = { 1, 1, mask->ne[2], nr2, 1, 1 };
@@ -1562,17 +1903,13 @@ static void aclnn_add_alibi(ggml_backend_cann_context& ctx, ggml_tensor* mask,
         slope_nb[i] = slope_nb[i - 1] * slope_ne[i - 1];
     }
 
-    aclTensor* acl_slope = ggml_cann_create_tensor(
-                            slope_buffer, ACL_FLOAT, sizeof(float),
-                            slope_ne, slope_nb, GGML_MAX_DIMS + 2);
-    aclTensor* acl_mask = ggml_cann_create_tensor(
-                            mask, mask_ne, mask_nb, GGML_MAX_DIMS + 2);
+    aclTensor * acl_slope =
+        ggml_cann_create_tensor(slope_buffer, ACL_FLOAT, sizeof(float), slope_ne, slope_nb, GGML_MAX_DIMS + 2);
+    aclTensor * acl_mask = ggml_cann_create_tensor(mask, mask_ne, mask_nb, GGML_MAX_DIMS + 2);
 
     // write data into dst_ptr using only the shape information of the dst tensor.
-    aclTensor* acl_dst  = ggml_cann_create_tensor(
-                            dst_ptr, ggml_cann_type_mapping(dst->type),
-                            ggml_type_size(dst->type), dst_ne, dst_nb,
-                            GGML_MAX_DIMS + 2);
+    aclTensor * acl_dst = ggml_cann_create_tensor(
+        dst_ptr, ggml_cann_type_mapping(dst->type), ggml_type_size(dst->type), dst_ne, dst_nb, GGML_MAX_DIMS + 2);
 
     if (max_bias > 0.0f) {
         int64_t bias_ne[] = { mask->ne[0], dst->ne[1], mask->ne[2], nr2, mask->ne[3], 1 };
@@ -1581,9 +1918,8 @@ static void aclnn_add_alibi(ggml_backend_cann_context& ctx, ggml_tensor* mask,
         for (int i = 1; i < GGML_MAX_DIMS + 2; i++) {
             bias_nb[i] = bias_nb[i - 1] * bias_ne[i - 1];
         }
-        aclTensor* bias_tensor = ggml_cann_create_tensor(
-                                    bias_buffer, ACL_FLOAT, sizeof(float),
-                                    bias_ne, bias_nb, GGML_MAX_DIMS + 2);
+        aclTensor * bias_tensor =
+            ggml_cann_create_tensor(bias_buffer, ACL_FLOAT, sizeof(float), bias_ne, bias_nb, GGML_MAX_DIMS + 2);
 
         aclnn_mul(ctx, acl_slope, acl_mask, bias_tensor);
         aclnn_add(ctx, acl_dst, bias_tensor);
@@ -1612,17 +1948,16 @@ void ggml_cann_cpy(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
  * @param acl_dst The destination tensor where the softmax results will be
  * stored.
  */
-static void aclnn_softmax(ggml_backend_cann_context & ctx,
-    aclTensor* acl_src, int64_t dim, aclTensor * acl_dst) {
+static void aclnn_softmax(ggml_backend_cann_context & ctx, aclTensor * acl_src, int64_t dim, aclTensor * acl_dst) {
     GGML_CANN_CALL_ACLNN_OP(ctx, Softmax, acl_src, dim, acl_dst);
 }
 
 void ggml_cann_softmax(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
-    ggml_tensor* src0 = dst->src[0];
-    ggml_tensor* src1 = dst->src[1];  // mask
+    ggml_tensor * src0 = dst->src[0];
+    ggml_tensor * src1 = dst->src[1];  // mask
 
-    aclTensor* acl_src0 = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst  = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src0 = ggml_cann_create_tensor(src0);
+    aclTensor * acl_dst  = ggml_cann_create_tensor(dst);
 
     float scale    = 1.0f;
     float max_bias = 0.0f;
@@ -1631,12 +1966,15 @@ void ggml_cann_softmax(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     memcpy(&max_bias, (float *) dst->op_params + 1, sizeof(float));
 
     // input mul scale
-    aclScalar* acl_scale = aclCreateScalar(&scale, aclDataType::ACL_FLOAT);
+    aclScalar *          acl_scale = aclCreateScalar(&scale, aclDataType::ACL_FLOAT);
     ggml_cann_pool_alloc src_tensor_allocator(ctx.pool(), ggml_nbytes(src0));
-    void* src_tensor_buffer = src_tensor_allocator.get();
-    aclTensor* softmax_tensor = ggml_cann_create_tensor(
-        src_tensor_buffer, ggml_cann_type_mapping(src0->type),
-        ggml_element_size(src0), src0->ne, src0->nb,GGML_MAX_DIMS);
+    void *               src_tensor_buffer = src_tensor_allocator.get();
+    aclTensor *          softmax_tensor    = ggml_cann_create_tensor(src_tensor_buffer,
+                                                         ggml_cann_type_mapping(src0->type),
+                                                         ggml_element_size(src0),
+                                                         src0->ne,
+                                                         src0->nb,
+                                                         GGML_MAX_DIMS);
 
     aclnn_muls(ctx, acl_src0, scale, softmax_tensor, false);
 
@@ -1668,29 +2006,41 @@ void ggml_cann_softmax(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
  * @param index The index tensor specifying the indices to select from the source tensor.
  * @param type The data type of the source and destination tensors.
  */
-static void aclnn_index_select_4d(ggml_backend_cann_context& ctx,
-                                void* src_buffer,int64_t* src_ne, size_t* src_nb,
-                                void* dst_buffer, int64_t* dst_ne, size_t* dst_nb,
-                                ggml_tensor* index, ggml_type type) {
+static void aclnn_index_select_4d(ggml_backend_cann_context & ctx,
+                                  void *                      src_buffer,
+                                  int64_t *                   src_ne,
+                                  size_t *                    src_nb,
+                                  void *                      dst_buffer,
+                                  int64_t *                   dst_ne,
+                                  size_t *                    dst_nb,
+                                  ggml_tensor *               index,
+                                  ggml_type                   type) {
     for (int64_t i = 0; i < src_ne[3]; i++) {
         for (int64_t j = 0; j < src_ne[2]; j++) {
             // src
-            aclTensor* acl_src_tensor = ggml_cann_create_tensor(
-                (char*)src_buffer + i * src_nb[3] + j * src_nb[2],
-                ggml_cann_type_mapping(type), ggml_type_size(type),
-                src_ne, src_nb, 2);
+            aclTensor * acl_src_tensor = ggml_cann_create_tensor((char *) src_buffer + i * src_nb[3] + j * src_nb[2],
+                                                                 ggml_cann_type_mapping(type),
+                                                                 ggml_type_size(type),
+                                                                 src_ne,
+                                                                 src_nb,
+                                                                 2);
 
             // index
-            aclTensor* acl_index = ggml_cann_create_tensor(
-                (char*)index->data + (i % index->ne[2]) * index->nb[2] + (j % index->ne[1]) * index->nb[1],
-                ggml_cann_type_mapping(index->type), ggml_element_size(index),
-                index->ne, index->nb, 1);
+            aclTensor * acl_index = ggml_cann_create_tensor(
+                (char *) index->data + (i % index->ne[2]) * index->nb[2] + (j % index->ne[1]) * index->nb[1],
+                ggml_cann_type_mapping(index->type),
+                ggml_element_size(index),
+                index->ne,
+                index->nb,
+                1);
 
             // out
-            aclTensor* acl_out = ggml_cann_create_tensor(
-                (char*)dst_buffer + i * dst_nb[3] + j * dst_nb[2],
-                ggml_cann_type_mapping(type), ggml_type_size(type),
-                dst_ne, dst_nb, 2);
+            aclTensor * acl_out = ggml_cann_create_tensor((char *) dst_buffer + i * dst_nb[3] + j * dst_nb[2],
+                                                          ggml_cann_type_mapping(type),
+                                                          ggml_type_size(type),
+                                                          dst_ne,
+                                                          dst_nb,
+                                                          2);
             GGML_CANN_CALL_ACLNN_OP(ctx, IndexSelect, acl_src_tensor, 0, acl_index, acl_out);
             ggml_cann_release_resources(ctx, acl_src_tensor, acl_index, acl_out);
         }
@@ -1717,167 +2067,184 @@ static void aclnn_index_select_4d(ggml_backend_cann_context& ctx,
  * @param index The index tensor specifying target positions in the destination tensor.
  * @param type The data type of the source and destination tensors.
  */
-static void aclnn_index_copy_4d(ggml_backend_cann_context& ctx,
-                                void* src_buffer,int64_t* src_ne, size_t* src_nb,
-                                void* dst_buffer, int64_t* dst_ne, size_t* dst_nb,
-                                ggml_tensor* index, ggml_type type) {
+static void aclnn_index_copy_4d(ggml_backend_cann_context & ctx,
+                                void *                      src_buffer,
+                                int64_t *                   src_ne,
+                                size_t *                    src_nb,
+                                void *                      dst_buffer,
+                                int64_t *                   dst_ne,
+                                size_t *                    dst_nb,
+                                ggml_tensor *               index,
+                                ggml_type                   type) {
     for (int64_t i = 0; i < src_ne[3]; i++) {
         for (int64_t j = 0; j < src_ne[2]; j++) {
             // src
-            aclTensor* acl_src_tensor = ggml_cann_create_tensor(
-                (char*)src_buffer + i * src_nb[3] + j * src_nb[2],
-                ggml_cann_type_mapping(type), ggml_type_size(type),
-                src_ne, src_nb, 2);
+            aclTensor * acl_src_tensor = ggml_cann_create_tensor((char *) src_buffer + i * src_nb[3] + j * src_nb[2],
+                                                                 ggml_cann_type_mapping(type),
+                                                                 ggml_type_size(type),
+                                                                 src_ne,
+                                                                 src_nb,
+                                                                 2);
 
             // index
-            aclTensor* acl_index = ggml_cann_create_tensor(
-                (char*)index->data + (i % index->ne[2]) * index->nb[2] + (j % index->ne[1]) * index->nb[1],
-                ggml_cann_type_mapping(index->type), ggml_element_size(index),
-                index->ne, index->nb, 1);
+            aclTensor * acl_index = ggml_cann_create_tensor(
+                (char *) index->data + (i % index->ne[2]) * index->nb[2] + (j % index->ne[1]) * index->nb[1],
+                ggml_cann_type_mapping(index->type),
+                ggml_element_size(index),
+                index->ne,
+                index->nb,
+                1);
 
             // out
-            aclTensor* acl_out = ggml_cann_create_tensor(
-                (char*)dst_buffer + i * dst_nb[3] + j * dst_nb[2],
-                ggml_cann_type_mapping(type), ggml_type_size(type),
-                dst_ne, dst_nb, 2);
+            aclTensor * acl_out = ggml_cann_create_tensor((char *) dst_buffer + i * dst_nb[3] + j * dst_nb[2],
+                                                          ggml_cann_type_mapping(type),
+                                                          ggml_type_size(type),
+                                                          dst_ne,
+                                                          dst_nb,
+                                                          2);
             GGML_CANN_CALL_ACLNN_OP(ctx, InplaceIndexCopy, acl_out, 0, acl_index, acl_src_tensor);
             ggml_cann_release_resources(ctx, acl_src_tensor, acl_index, acl_out);
         }
     }
 }
 
-void ggml_cann_get_rows(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];  // src
-    ggml_tensor* src1 = dst->src[1];  // index
+void ggml_cann_get_rows(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0 = dst->src[0];  // src
+    ggml_tensor * src1 = dst->src[1];  // index
 
     switch (src0->type) {
-        case GGML_TYPE_F32: {
-            aclnn_index_select_4d(ctx, src0->data, src0->ne, src0->nb,
-                                dst->data, dst->ne, dst->nb,
-                                src1, dst->type);
-            break;
-        }
-        case GGML_TYPE_F16: {
-            aclTensor* acl_src0 = ggml_cann_create_tensor(src0);
-            ggml_cann_pool_alloc src_buffer_allocator(
-                ctx.pool(), ggml_nelements(src0) * sizeof(float_t));
-            void* src_trans_buffer = src_buffer_allocator.get();
-            size_t src_trans_nb[GGML_MAX_DIMS];
-            src_trans_nb[0] = sizeof(float_t);
-            for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
+        case GGML_TYPE_F32:
+            {
+                aclnn_index_select_4d(
+                    ctx, src0->data, src0->ne, src0->nb, dst->data, dst->ne, dst->nb, src1, dst->type);
+                break;
             }
-            aclTensor* src_trans_tensor = ggml_cann_create_tensor(
-                src_trans_buffer, ACL_FLOAT, ggml_type_size(dst->type),
-                src0->ne, src_trans_nb, GGML_MAX_DIMS);
-            aclnn_cast(ctx, acl_src0, src_trans_tensor, ggml_cann_type_mapping(dst->type));
-            aclnn_index_select_4d(ctx, src_trans_buffer, src0->ne, src_trans_nb,
-                                dst->data, dst->ne, dst->nb,
-                                src1, dst->type);
-            ggml_cann_release_resources(ctx, acl_src0, src_trans_tensor);
-            break;
-        }
-        case GGML_TYPE_Q8_0: {
-            // add 1 dim for bcast mul.
-            size_t weight_nb[GGML_MAX_DIMS + 1], scale_nb[GGML_MAX_DIMS + 1],
-                dequant_nb[GGML_MAX_DIMS + 1];
-            int64_t weight_ne[GGML_MAX_DIMS + 1], scale_ne[GGML_MAX_DIMS + 1],
-                *dequant_ne;
-            int64_t scale_offset = 0;
-
-            // [3,4,5,64] -> [3,4,5,2,32]
-            weight_ne[0] = QK8_0;
-            weight_ne[1] = src0->ne[0] / QK8_0;
-            weight_nb[0] = sizeof(int8_t);
-            weight_nb[1] = weight_nb[0] * weight_ne[0];
-            for (int i = 2; i < GGML_MAX_DIMS + 1; i++) {
-                weight_ne[i] = src0->ne[i - 1];
-                weight_nb[i] = weight_nb[i - 1] * weight_ne[i - 1];
+        case GGML_TYPE_F16:
+            {
+                aclTensor *          acl_src0 = ggml_cann_create_tensor(src0);
+                ggml_cann_pool_alloc src_buffer_allocator(ctx.pool(), ggml_nelements(src0) * sizeof(float_t));
+                void *               src_trans_buffer = src_buffer_allocator.get();
+                size_t               src_trans_nb[GGML_MAX_DIMS];
+                src_trans_nb[0] = sizeof(float_t);
+                for (int i = 1; i < GGML_MAX_DIMS; i++) {
+                    src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
+                }
+                aclTensor * src_trans_tensor = ggml_cann_create_tensor(
+                    src_trans_buffer, ACL_FLOAT, ggml_type_size(dst->type), src0->ne, src_trans_nb, GGML_MAX_DIMS);
+                aclnn_cast(ctx, acl_src0, src_trans_tensor, ggml_cann_type_mapping(dst->type));
+                aclnn_index_select_4d(
+                    ctx, src_trans_buffer, src0->ne, src_trans_nb, dst->data, dst->ne, dst->nb, src1, dst->type);
+                ggml_cann_release_resources(ctx, acl_src0, src_trans_tensor);
+                break;
             }
+        case GGML_TYPE_Q8_0:
+            {
+                // add 1 dim for bcast mul.
+                size_t  weight_nb[GGML_MAX_DIMS + 1], scale_nb[GGML_MAX_DIMS + 1], dequant_nb[GGML_MAX_DIMS + 1];
+                int64_t weight_ne[GGML_MAX_DIMS + 1], scale_ne[GGML_MAX_DIMS + 1], *dequant_ne;
+                int64_t scale_offset = 0;
 
-            // [3,4,5,64] -> [3,4,5,2,1]
-            scale_ne[0] = 1;
-            scale_ne[1] = src0->ne[0] / QK8_0;
-            scale_nb[0] = sizeof(uint16_t);
-            scale_nb[1] = scale_nb[0] * scale_ne[0];
-            for (int i = 2; i < GGML_MAX_DIMS + 1; i++) {
-                scale_ne[i] = src0->ne[i - 1];
-                scale_nb[i] = scale_nb[i - 1] * scale_ne[i - 1];
+                // [3,4,5,64] -> [3,4,5,2,32]
+                weight_ne[0] = QK8_0;
+                weight_ne[1] = src0->ne[0] / QK8_0;
+                weight_nb[0] = sizeof(int8_t);
+                weight_nb[1] = weight_nb[0] * weight_ne[0];
+                for (int i = 2; i < GGML_MAX_DIMS + 1; i++) {
+                    weight_ne[i] = src0->ne[i - 1];
+                    weight_nb[i] = weight_nb[i - 1] * weight_ne[i - 1];
+                }
+
+                // [3,4,5,64] -> [3,4,5,2,1]
+                scale_ne[0] = 1;
+                scale_ne[1] = src0->ne[0] / QK8_0;
+                scale_nb[0] = sizeof(uint16_t);
+                scale_nb[1] = scale_nb[0] * scale_ne[0];
+                for (int i = 2; i < GGML_MAX_DIMS + 1; i++) {
+                    scale_ne[i] = src0->ne[i - 1];
+                    scale_nb[i] = scale_nb[i - 1] * scale_ne[i - 1];
+                }
+
+                // [3,4,5,64] -> [3,4,5,2,32]
+                dequant_ne    = weight_ne;
+                dequant_nb[0] = sizeof(float_t);
+                for (int i = 1; i < GGML_MAX_DIMS + 1; i++) {
+                    dequant_nb[i] = dequant_nb[i - 1] * dequant_ne[i - 1];
+                }
+
+                scale_offset = ggml_nelements(src0) * sizeof(int8_t);
+                ggml_cann_pool_alloc dequant_buffer_allocator(ctx.pool(), ggml_nelements(src0) * sizeof(float_t));
+
+                aclTensor * acl_weight_tensor = ggml_cann_create_tensor(
+                    src0->data, ACL_INT8, sizeof(int8_t), weight_ne, weight_nb, GGML_MAX_DIMS + 1);
+                aclTensor * acl_scale_tensor = ggml_cann_create_tensor(src0->data,
+                                                                       ACL_FLOAT16,
+                                                                       sizeof(uint16_t),
+                                                                       scale_ne,
+                                                                       scale_nb,
+                                                                       GGML_MAX_DIMS + 1,
+                                                                       ACL_FORMAT_ND,
+                                                                       scale_offset);
+                aclTensor * dequant_tensor   = ggml_cann_create_tensor(dequant_buffer_allocator.get(),
+                                                                     ACL_FLOAT,
+                                                                     sizeof(float_t),
+                                                                     dequant_ne,
+                                                                     dequant_nb,
+                                                                     GGML_MAX_DIMS + 1);
+
+                aclnn_mul(ctx, acl_weight_tensor, acl_scale_tensor, dequant_tensor);
+                dequant_nb[0] = sizeof(float_t);
+                dequant_ne    = src0->ne;
+                for (int i = 1; i < GGML_MAX_DIMS; i++) {
+                    dequant_nb[i] = dequant_nb[i - 1] * src0->ne[i - 1];
+                }
+
+                aclnn_index_select_4d(ctx,
+                                      dequant_buffer_allocator.get(),
+                                      dequant_ne,
+                                      dequant_nb,
+                                      dst->data,
+                                      dst->ne,
+                                      dst->nb,
+                                      src1,
+                                      dst->type);
+
+                ggml_cann_release_resources(ctx, dequant_tensor);
+                break;
             }
-
-            // [3,4,5,64] -> [3,4,5,2,32]
-            dequant_ne = weight_ne;
-            dequant_nb[0] = sizeof(float_t);
-            for (int i = 1; i < GGML_MAX_DIMS + 1; i++) {
-                dequant_nb[i] = dequant_nb[i - 1] * dequant_ne[i - 1];
-            }
-
-            scale_offset = ggml_nelements(src0) * sizeof(int8_t);
-            ggml_cann_pool_alloc dequant_buffer_allocator(
-                ctx.pool(), ggml_nelements(src0) * sizeof(float_t));
-
-            aclTensor* acl_weight_tensor = ggml_cann_create_tensor(
-                src0->data, ACL_INT8, sizeof(int8_t), weight_ne, weight_nb,
-                GGML_MAX_DIMS + 1);
-            aclTensor* acl_scale_tensor = ggml_cann_create_tensor(
-                src0->data, ACL_FLOAT16, sizeof(uint16_t), scale_ne, scale_nb,
-                GGML_MAX_DIMS + 1, ACL_FORMAT_ND, scale_offset);
-            aclTensor* dequant_tensor = ggml_cann_create_tensor(
-                dequant_buffer_allocator.get(), ACL_FLOAT, sizeof(float_t),
-                dequant_ne, dequant_nb, GGML_MAX_DIMS + 1);
-
-            aclnn_mul(ctx, acl_weight_tensor, acl_scale_tensor, dequant_tensor);
-            dequant_nb[0] = sizeof(float_t);
-            dequant_ne = src0->ne;
-            for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                dequant_nb[i] = dequant_nb[i - 1] * src0->ne[i - 1];
-            }
-
-            aclnn_index_select_4d(ctx, dequant_buffer_allocator.get(),
-                                   dequant_ne, dequant_nb,
-                                   dst->data, dst->ne, dst->nb,
-                                   src1, dst->type);
-
-            ggml_cann_release_resources(ctx, dequant_tensor);
-            break;
-        }
         default:
             GGML_ABORT("Unsupported tensor type for GGML_OP_GET_ROWS");
             break;
     }
 }
 
-void ggml_cann_set_rows(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
-    ggml_tensor* src0 = dst->src[0];  // src
-    ggml_tensor* src1 = dst->src[1];  // index
+void ggml_cann_set_rows(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0 = dst->src[0];  // src
+    ggml_tensor * src1 = dst->src[1];  // index
 
     switch (dst->type) {
-        case GGML_TYPE_F32: {
-            aclnn_index_copy_4d(ctx, src0->data, src0->ne, src0->nb,
-                                dst->data, dst->ne, dst->nb,
-                                src1, dst->type);
-            break;
-        }
-        case GGML_TYPE_F16: {
-            aclTensor* acl_src0 = ggml_cann_create_tensor(src0);
-            ggml_cann_pool_alloc src_buffer_allocator(
-                ctx.pool(), ggml_nelements(src0) * sizeof(uint16_t));
-            void* src_trans_buffer = src_buffer_allocator.get();
-            size_t src_trans_nb[GGML_MAX_DIMS];
-            src_trans_nb[0] = sizeof(uint16_t);
-            for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
+        case GGML_TYPE_F32:
+            {
+                aclnn_index_copy_4d(ctx, src0->data, src0->ne, src0->nb, dst->data, dst->ne, dst->nb, src1, dst->type);
+                break;
             }
-            aclTensor* src_trans_tensor = ggml_cann_create_tensor(
-                src_trans_buffer, ACL_FLOAT16, ggml_type_size(dst->type),
-                src0->ne, src_trans_nb, GGML_MAX_DIMS);
-            aclnn_cast(ctx, acl_src0, src_trans_tensor, ggml_cann_type_mapping(dst->type));
-            aclnn_index_copy_4d(ctx, src_trans_buffer, src0->ne, src_trans_nb,
-                                dst->data, dst->ne, dst->nb,
-                                src1, dst->type);
-            ggml_cann_release_resources(ctx, acl_src0, src_trans_tensor);
-            break;
-        }
+        case GGML_TYPE_F16:
+            {
+                aclTensor *          acl_src0 = ggml_cann_create_tensor(src0);
+                ggml_cann_pool_alloc src_buffer_allocator(ctx.pool(), ggml_nelements(src0) * sizeof(uint16_t));
+                void *               src_trans_buffer = src_buffer_allocator.get();
+                size_t               src_trans_nb[GGML_MAX_DIMS];
+                src_trans_nb[0] = sizeof(uint16_t);
+                for (int i = 1; i < GGML_MAX_DIMS; i++) {
+                    src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
+                }
+                aclTensor * src_trans_tensor = ggml_cann_create_tensor(
+                    src_trans_buffer, ACL_FLOAT16, ggml_type_size(dst->type), src0->ne, src_trans_nb, GGML_MAX_DIMS);
+                aclnn_cast(ctx, acl_src0, src_trans_tensor, ggml_cann_type_mapping(dst->type));
+                aclnn_index_copy_4d(
+                    ctx, src_trans_buffer, src0->ne, src_trans_nb, dst->data, dst->ne, dst->nb, src1, dst->type);
+                ggml_cann_release_resources(ctx, acl_src0, src_trans_tensor);
+                break;
+            }
         default:
             GGML_ABORT("Unsupported tensor type for GGML_OP_SET_ROWS");
             break;
@@ -1899,12 +2266,13 @@ void ggml_cann_set_rows(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param repeats The number of times each element will be repeated.
  * @param output_size The size of the output tensor.
  */
-static void aclnn_repeat_interleave(ggml_backend_cann_context& ctx,
-                                    aclTensor* acl_src, aclTensor* acl_dst,
-                                    int64_t dim, int64_t repeats,
-                                    int64_t output_size) {
-    GGML_CANN_CALL_ACLNN_OP(ctx, RepeatInterleaveIntWithDim, acl_src, repeats, dim,
-                  output_size, acl_dst);
+static void aclnn_repeat_interleave(ggml_backend_cann_context & ctx,
+                                    aclTensor *                 acl_src,
+                                    aclTensor *                 acl_dst,
+                                    int64_t                     dim,
+                                    int64_t                     repeats,
+                                    int64_t                     output_size) {
+    GGML_CANN_CALL_ACLNN_OP(ctx, RepeatInterleaveIntWithDim, acl_src, repeats, dim, output_size, acl_dst);
 }
 
 /**
@@ -1919,10 +2287,9 @@ static void aclnn_repeat_interleave(ggml_backend_cann_context& ctx,
  * @param dst The destination tensor where the result of the matrix
  * multiplication will be stored.
  */
-static void ggml_cann_mat_mul_fp(ggml_backend_cann_context& ctx,
-                                 ggml_tensor* dst) {
-    ggml_tensor* weight = dst->src[0];  // weight
-    ggml_tensor* input = dst->src[1];   // input
+static void ggml_cann_mat_mul_fp(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * weight = dst->src[0];  // weight
+    ggml_tensor * input  = dst->src[1];  // input
 
     // when weight ne2 or ne3 is 1, aclnnMatmulGetWorkspaceSize will auto
     // broadcast, when weight ne2 or ne3 is not 1, weight need repeat.
@@ -1937,35 +2304,36 @@ static void ggml_cann_mat_mul_fp(ggml_backend_cann_context& ctx,
         }
     }
 
-    aclTensor* acl_input_tensor =
-        ggml_cann_create_tensor(input, bcast_input_ne, bcast_input_nb, n_dims);
-    int64_t transpose_ne[] = {bcast_weight_ne[1], bcast_weight_ne[0],
-                              bcast_weight_ne[2], bcast_weight_ne[3],
-                              bcast_weight_ne[4], bcast_weight_ne[5]};
-    size_t transpose_nb[] = {bcast_weight_nb[1], bcast_weight_nb[0],
-                             bcast_weight_nb[2], bcast_weight_nb[3],
-                             bcast_weight_nb[4], bcast_weight_nb[5]};
-    aclTensor* acl_weight_tensor;
+    aclTensor * acl_input_tensor = ggml_cann_create_tensor(input, bcast_input_ne, bcast_input_nb, n_dims);
+    int64_t     transpose_ne[]   = { bcast_weight_ne[1], bcast_weight_ne[0], bcast_weight_ne[2],
+                                     bcast_weight_ne[3], bcast_weight_ne[4], bcast_weight_ne[5] };
+    size_t      transpose_nb[]   = { bcast_weight_nb[1], bcast_weight_nb[0], bcast_weight_nb[2],
+                                     bcast_weight_nb[3], bcast_weight_nb[4], bcast_weight_nb[5] };
+    aclTensor * acl_weight_tensor;
 
     // Only check env once.
     static bool weight_to_nz = parse_bool(get_env("GGML_CANN_WEIGHT_NZ").value_or(""));
     if (weight_to_nz && is_matmul_weight(weight)) {
-        int64_t acl_stride[2] = {1, transpose_ne[1]};
+        int64_t acl_stride[2] = { 1, transpose_ne[1] };
 
         // Reverse ne.
         std::reverse(transpose_ne, transpose_ne + n_dims);
 
-        std::vector<int64_t> storageDims = {transpose_ne[0], transpose_ne[1]};
+        std::vector<int64_t> storageDims = { transpose_ne[0], transpose_ne[1] };
 
-        acl_weight_tensor = aclCreateTensor(
-            transpose_ne, n_dims, ggml_cann_type_mapping(weight->type), acl_stride,
-            0, ACL_FORMAT_FRACTAL_NZ, storageDims.data(), 2, weight->data);
+        acl_weight_tensor = aclCreateTensor(transpose_ne,
+                                            n_dims,
+                                            ggml_cann_type_mapping(weight->type),
+                                            acl_stride,
+                                            0,
+                                            ACL_FORMAT_FRACTAL_NZ,
+                                            storageDims.data(),
+                                            2,
+                                            weight->data);
     } else {
-        acl_weight_tensor =
-            ggml_cann_create_tensor(weight, transpose_ne, transpose_nb, n_dims, ACL_FORMAT_ND);
+        acl_weight_tensor = ggml_cann_create_tensor(weight, transpose_ne, transpose_nb, n_dims, ACL_FORMAT_ND);
     }
-    aclTensor* acl_dst =
-        ggml_cann_create_tensor(dst, bcast_dst_ne, bcast_dst_nb, n_dims);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst, bcast_dst_ne, bcast_dst_nb, n_dims);
 
     switch (n_dims) {
         case 2:
@@ -1997,11 +2365,9 @@ static void ggml_cann_mat_mul_fp(ggml_backend_cann_context& ctx,
  * @param dst The destination tensor where the result of the matrix
  * multiplication will be stored.
  */
-static void ggml_cann_mul_mat_quant(ggml_backend_cann_context& ctx,
-                                    ggml_tensor* dst,
-                                    const enum ggml_type type) {
-    ggml_tensor* src0 = dst->src[0];  // weight
-    ggml_tensor* src1 = dst->src[1];  // input
+static void ggml_cann_mul_mat_quant(ggml_backend_cann_context & ctx, ggml_tensor * dst, const enum ggml_type type) {
+    ggml_tensor * src0 = dst->src[0];  // weight
+    ggml_tensor * src1 = dst->src[1];  // input
 
     // The shape of the weight is NCHW.
     // Matrix multiplication uses HW dims.
@@ -2015,56 +2381,52 @@ static void ggml_cann_mul_mat_quant(ggml_backend_cann_context& ctx,
     } else {
         GGML_ABORT("Only support Q4_0 and Q8_0 MUL_MAT");
     }
-    float weight_nb[] = {src0->ne[0] * weight_elem_size, weight_elem_size};
+    float  weight_nb[]   = { src0->ne[0] * weight_elem_size, weight_elem_size };
     size_t weight_stride = src0->ne[1] * src0->ne[0] * weight_elem_size;
-    size_t weight_size = weight_stride * src0->ne[2] * src0->ne[3];
+    size_t weight_size   = weight_stride * src0->ne[2] * src0->ne[3];
 
     // scale stored at the end of weight. Also need transpose.
     size_t scale_elem_size = sizeof(uint16_t);
-    size_t scale_nb[] = {src0->ne[0] / QK8_0 * scale_elem_size,
-                         scale_elem_size};
-    size_t scale_stride = src0->ne[1] * src0->ne[0] / QK8_0 * scale_elem_size;
-    char* scale_offset = (char*)src0->data + weight_size;
+    size_t scale_nb[]      = { src0->ne[0] / QK8_0 * scale_elem_size, scale_elem_size };
+    size_t scale_stride    = src0->ne[1] * src0->ne[0] / QK8_0 * scale_elem_size;
+    char * scale_offset    = (char *) src0->data + weight_size;
 
     // input
-    size_t input_elem_size = sizeof(uint16_t);
-    int64_t input_ne[] = {src1->ne[0], src1->ne[1]};
-    size_t input_nb[] = {input_elem_size, input_ne[0] * input_elem_size};
-    size_t input_stride = input_ne[0] * input_ne[1] * input_elem_size;
+    size_t               input_elem_size = sizeof(uint16_t);
+    int64_t              input_ne[]      = { src1->ne[0], src1->ne[1] };
+    size_t               input_nb[]      = { input_elem_size, input_ne[0] * input_elem_size };
+    size_t               input_stride    = input_ne[0] * input_ne[1] * input_elem_size;
     ggml_cann_pool_alloc input_alloctor(ctx.pool());
-    void* input_buffer = src1->data;
+    void *               input_buffer = src1->data;
 
     // case in
     if (src1->type != GGML_TYPE_F16) {
-        aclTensor* acl_src1_tensor = ggml_cann_create_tensor(src1);
-        input_buffer =
-            input_alloctor.alloc(ggml_nelements(src1) * input_elem_size);
+        aclTensor * acl_src1_tensor = ggml_cann_create_tensor(src1);
+        input_buffer                = input_alloctor.alloc(ggml_nelements(src1) * input_elem_size);
 
-        int64_t* input_cast_ne = src1->ne;
-        size_t input_cast_nb[GGML_MAX_DIMS];
+        int64_t * input_cast_ne = src1->ne;
+        size_t    input_cast_nb[GGML_MAX_DIMS];
         input_cast_nb[0] = sizeof(uint16_t);
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             input_cast_nb[i] = input_cast_nb[i - 1] * input_cast_ne[i - 1];
         }
 
-        aclTensor* acl_input_tensor = ggml_cann_create_tensor(
-            input_buffer, ACL_FLOAT16, input_elem_size, input_cast_ne,
-            input_cast_nb, GGML_MAX_DIMS);
+        aclTensor * acl_input_tensor = ggml_cann_create_tensor(
+            input_buffer, ACL_FLOAT16, input_elem_size, input_cast_ne, input_cast_nb, GGML_MAX_DIMS);
         aclnn_cast(ctx, acl_src1_tensor, acl_input_tensor, ACL_FLOAT16);
         ggml_cann_release_resources(ctx, acl_input_tensor, acl_src1_tensor);
     }
 
     // output
-    size_t output_elem_size = sizeof(uint16_t);
-    size_t output_nb[] = {output_elem_size, dst->ne[0] * output_elem_size};
+    size_t               output_elem_size = sizeof(uint16_t);
+    size_t               output_nb[]      = { output_elem_size, dst->ne[0] * output_elem_size };
     ggml_cann_pool_alloc output_allocator(ctx.pool());
-    void* output_buffer =
-        output_allocator.alloc(ggml_nelements(dst) * output_elem_size);
-    size_t output_stride = dst->ne[0] * dst->ne[1] * output_elem_size;
+    void *               output_buffer = output_allocator.alloc(ggml_nelements(dst) * output_elem_size);
+    size_t               output_stride = dst->ne[0] * dst->ne[1] * output_elem_size;
 
     // aclnn
-    int64_t max_elem_size = 65535;
-    int64_t split_size = (src0->ne[1] / max_elem_size) + 1;
+    int64_t              max_elem_size = 65535;
+    int64_t              split_size    = (src0->ne[1] / max_elem_size) + 1;
     ggml_cann_pool_alloc workspace_allocator(ctx.pool());
     for (int64_t n1 = 0; n1 < src1->ne[3]; n1++) {
         for (int64_t c1 = 0; c1 < src1->ne[2]; c1++) {
@@ -2074,71 +2436,103 @@ static void ggml_cann_mul_mat_quant(ggml_backend_cann_context& ctx,
             int64_t batch1 = (n1 * src1->ne[2]) + c1;
             int64_t batch0 = (n0 * src0->ne[2]) + c0;
 
-            aclTensor* acl_input_tensor = ggml_cann_create_tensor(
-                (char*)input_buffer + batch1 * input_stride, ACL_FLOAT16,
-                input_elem_size, input_ne, input_nb, 2);
+            aclTensor * acl_input_tensor = ggml_cann_create_tensor(
+                (char *) input_buffer + batch1 * input_stride, ACL_FLOAT16, input_elem_size, input_ne, input_nb, 2);
 
             // first split
             int64_t weight_ne_offset = 0;
-            int64_t weight_ne[2] = {
-                max_elem_size > src0->ne[1] ? src0->ne[1] : max_elem_size,
-                src0->ne[0]};
-            int64_t scale_ne_offset = 0;
-            int64_t scale_ne[2] = {weight_ne[0], weight_ne[1] / QK8_0};
+            int64_t weight_ne[2]     = { max_elem_size > src0->ne[1] ? src0->ne[1] : max_elem_size, src0->ne[0] };
+            int64_t scale_ne_offset  = 0;
+            int64_t scale_ne[2]      = { weight_ne[0], weight_ne[1] / QK8_0 };
             int64_t output_ne_offset = 0;
-            int64_t output_ne[2] = {weight_ne[0], dst->ne[1]};
+            int64_t output_ne[2]     = { weight_ne[0], dst->ne[1] };
 
-            aclTensor* acl_weight_tensor = ggml_cann_create_tensor(
-                (char*)src0->data + batch0 * weight_stride,
-                ggml_cann_type_mapping(type), weight_elem_size, weight_ne,
-                weight_nb, 2, ACL_FORMAT_ND, weight_ne_offset);
-            aclTensor* acl_scale_tensor = ggml_cann_create_tensor(
-                scale_offset + batch0 * scale_stride, ACL_FLOAT16,
-                scale_elem_size, scale_ne, scale_nb, 2, ACL_FORMAT_ND,
-                scale_ne_offset);
-            aclTensor* acl_output_tensor = ggml_cann_create_tensor(
-                (char*)output_buffer + batch1 * output_stride, ACL_FLOAT16,
-                output_elem_size, output_ne, output_nb, 2, ACL_FORMAT_ND,
-                output_ne_offset);
-            int64_t antiquantGroupSize = 0;
+            aclTensor * acl_weight_tensor  = ggml_cann_create_tensor((char *) src0->data + batch0 * weight_stride,
+                                                                    ggml_cann_type_mapping(type),
+                                                                    weight_elem_size,
+                                                                    weight_ne,
+                                                                    weight_nb,
+                                                                    2,
+                                                                    ACL_FORMAT_ND,
+                                                                    weight_ne_offset);
+            aclTensor * acl_scale_tensor   = ggml_cann_create_tensor(scale_offset + batch0 * scale_stride,
+                                                                   ACL_FLOAT16,
+                                                                   scale_elem_size,
+                                                                   scale_ne,
+                                                                   scale_nb,
+                                                                   2,
+                                                                   ACL_FORMAT_ND,
+                                                                   scale_ne_offset);
+            aclTensor * acl_output_tensor  = ggml_cann_create_tensor((char *) output_buffer + batch1 * output_stride,
+                                                                    ACL_FLOAT16,
+                                                                    output_elem_size,
+                                                                    output_ne,
+                                                                    output_nb,
+                                                                    2,
+                                                                    ACL_FORMAT_ND,
+                                                                    output_ne_offset);
+            int64_t     antiquantGroupSize = 0;
             if (src0->ne[0] > QK8_0) {
                 antiquantGroupSize = QK8_0;
             }
-            GGML_CANN_CALL_ACLNN_OP(ctx, WeightQuantBatchMatmulV2, acl_input_tensor,
-                           acl_weight_tensor, acl_scale_tensor, nullptr,
-                           nullptr, nullptr, nullptr, antiquantGroupSize,
-                           acl_output_tensor);
+            GGML_CANN_CALL_ACLNN_OP(ctx,
+                                    WeightQuantBatchMatmulV2,
+                                    acl_input_tensor,
+                                    acl_weight_tensor,
+                                    acl_scale_tensor,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    nullptr,
+                                    antiquantGroupSize,
+                                    acl_output_tensor);
             ggml_cann_release_resources(ctx, acl_weight_tensor, acl_scale_tensor, acl_output_tensor);
 
             // other splits
             for (int64_t split = 1; split < split_size; split++) {
-                weight_ne_offset +=
-                    weight_elem_size * weight_ne[0] * weight_ne[1];
-                weight_ne[0] = max_elem_size * (split + 1) > src0->ne[1]
-                                   ? src0->ne[1] - (max_elem_size * split)
-                                   : max_elem_size;
+                weight_ne_offset += weight_elem_size * weight_ne[0] * weight_ne[1];
+                weight_ne[0] =
+                    max_elem_size * (split + 1) > src0->ne[1] ? src0->ne[1] - (max_elem_size * split) : max_elem_size;
                 scale_ne_offset += scale_elem_size * scale_ne[0] * scale_ne[1];
                 scale_ne[0] = weight_ne[0];
-                output_ne_offset +=
-                    output_elem_size * output_ne[0] * output_ne[1];
+                output_ne_offset += output_elem_size * output_ne[0] * output_ne[1];
                 output_ne[0] = weight_ne[0];
 
-                acl_weight_tensor = ggml_cann_create_tensor(
-                    (char*)src0->data + batch0 * weight_stride,
-                    ggml_cann_type_mapping(type), weight_elem_size, weight_ne,
-                    weight_nb, 2, ACL_FORMAT_ND, weight_ne_offset);
-                acl_scale_tensor = ggml_cann_create_tensor(
-                    scale_offset + batch0 * scale_stride, ACL_FLOAT16,
-                    scale_elem_size, scale_ne, scale_nb, 2, ACL_FORMAT_ND,
-                    scale_ne_offset);
-                acl_output_tensor = ggml_cann_create_tensor(
-                    (char*)output_buffer + batch1 * output_stride, ACL_FLOAT16,
-                    output_elem_size, output_ne, output_nb, 2, ACL_FORMAT_ND,
-                    output_ne_offset);
-                GGML_CANN_CALL_ACLNN_OP(ctx, WeightQuantBatchMatmulV2, acl_input_tensor,
-                                   acl_weight_tensor, acl_scale_tensor, nullptr,
-                                   nullptr, nullptr, nullptr, antiquantGroupSize,
-                                   acl_output_tensor);
+                acl_weight_tensor = ggml_cann_create_tensor((char *) src0->data + batch0 * weight_stride,
+                                                            ggml_cann_type_mapping(type),
+                                                            weight_elem_size,
+                                                            weight_ne,
+                                                            weight_nb,
+                                                            2,
+                                                            ACL_FORMAT_ND,
+                                                            weight_ne_offset);
+                acl_scale_tensor  = ggml_cann_create_tensor(scale_offset + batch0 * scale_stride,
+                                                           ACL_FLOAT16,
+                                                           scale_elem_size,
+                                                           scale_ne,
+                                                           scale_nb,
+                                                           2,
+                                                           ACL_FORMAT_ND,
+                                                           scale_ne_offset);
+                acl_output_tensor = ggml_cann_create_tensor((char *) output_buffer + batch1 * output_stride,
+                                                            ACL_FLOAT16,
+                                                            output_elem_size,
+                                                            output_ne,
+                                                            output_nb,
+                                                            2,
+                                                            ACL_FORMAT_ND,
+                                                            output_ne_offset);
+                GGML_CANN_CALL_ACLNN_OP(ctx,
+                                        WeightQuantBatchMatmulV2,
+                                        acl_input_tensor,
+                                        acl_weight_tensor,
+                                        acl_scale_tensor,
+                                        nullptr,
+                                        nullptr,
+                                        nullptr,
+                                        nullptr,
+                                        antiquantGroupSize,
+                                        acl_output_tensor);
                 ggml_cann_release_resources(ctx, acl_weight_tensor, acl_scale_tensor, acl_output_tensor);
             }
 
@@ -2148,24 +2542,23 @@ static void ggml_cann_mul_mat_quant(ggml_backend_cann_context& ctx,
 
     // cast out
     if (dst->type != GGML_TYPE_F16) {
-        int64_t* output_cast_ne = dst->ne;
-        size_t output_cast_nb[GGML_MAX_DIMS];
+        int64_t * output_cast_ne = dst->ne;
+        size_t    output_cast_nb[GGML_MAX_DIMS];
         output_cast_nb[0] = sizeof(uint16_t);
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             output_cast_nb[i] = output_cast_nb[i - 1] * output_cast_ne[i - 1];
         }
 
-        aclTensor* acl_output_tensor = ggml_cann_create_tensor(
-            output_buffer, ACL_FLOAT16, output_elem_size, output_cast_ne,
-            output_cast_nb, GGML_MAX_DIMS);
-        aclTensor* acl_dst_tensor = ggml_cann_create_tensor(dst);
+        aclTensor * acl_output_tensor = ggml_cann_create_tensor(
+            output_buffer, ACL_FLOAT16, output_elem_size, output_cast_ne, output_cast_nb, GGML_MAX_DIMS);
+        aclTensor * acl_dst_tensor = ggml_cann_create_tensor(dst);
         aclnn_cast(ctx, acl_output_tensor, acl_dst_tensor, ggml_cann_type_mapping(dst->type));
 
         ggml_cann_release_resources(ctx, acl_output_tensor, acl_dst_tensor);
     }
 }
 
-void ggml_cann_mul_mat(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
+void ggml_cann_mul_mat(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     const enum ggml_type type = dst->src[0]->type;
     switch (type) {
         case GGML_TYPE_F32:
@@ -2198,10 +2591,13 @@ void ggml_cann_mul_mat(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param dims An array specifying the dimensions along which elements are
  * shifted.
  */
-static void aclnn_roll(ggml_backend_cann_context& ctx, aclTensor* acl_src,
-                       aclTensor* acl_dst, int64_t* shifts, int64_t* dims) {
-    aclIntArray* acl_shifts = aclCreateIntArray(shifts, 1);
-    aclIntArray* acl_dims = aclCreateIntArray(dims, 1);
+static void aclnn_roll(ggml_backend_cann_context & ctx,
+                       aclTensor *                 acl_src,
+                       aclTensor *                 acl_dst,
+                       int64_t *                   shifts,
+                       int64_t *                   dims) {
+    aclIntArray * acl_shifts = aclCreateIntArray(shifts, 1);
+    aclIntArray * acl_dims   = aclCreateIntArray(dims, 1);
     GGML_CANN_CALL_ACLNN_OP(ctx, Roll, acl_src, acl_shifts, acl_dims, acl_dst);
     ggml_cann_release_resources(ctx, acl_shifts, acl_dims);
 }
@@ -2219,12 +2615,14 @@ static void aclnn_roll(ggml_backend_cann_context& ctx, aclTensor* acl_src,
  * @param index_num The number of positions specified in the index array.
  * @param value The scalar value used to fill the specified positions.
  */
-static void aclnn_index_fill_tensor(ggml_backend_cann_context& ctx,
-                                    aclTensor* acl_src, int64_t dim,
-                                    int64_t* index, int64_t index_num,
-                                    float value) {
-    aclIntArray* acl_index = aclCreateIntArray(index, index_num);
-    aclScalar* acl_value = aclCreateScalar(&value, aclDataType::ACL_FLOAT);
+static void aclnn_index_fill_tensor(ggml_backend_cann_context & ctx,
+                                    aclTensor *                 acl_src,
+                                    int64_t                     dim,
+                                    int64_t *                   index,
+                                    int64_t                     index_num,
+                                    float                       value) {
+    aclIntArray * acl_index = aclCreateIntArray(index, index_num);
+    aclScalar *   acl_value = aclCreateScalar(&value, aclDataType::ACL_FLOAT);
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceIndexFillTensor, acl_src, dim, acl_index, acl_value);
     ggml_cann_release_resources(ctx, acl_index, acl_value);
 }
@@ -2261,9 +2659,12 @@ static void aclnn_index_fill_tensor(ggml_backend_cann_context& ctx,
  * @param is_neox     Whether to use Neox-style repeat strategy
  *                    (dim expansion vs repeat_interleave).
  */
-static void aclnn_cache_init(ggml_backend_cann_context& ctx, ggml_tensor* dst,
-                             float theta_scale, float freq_scale,
-                             float attn_factor, bool is_neox) {
+static void aclnn_cache_init(ggml_backend_cann_context & ctx,
+                             ggml_tensor *               dst,
+                             float                       theta_scale,
+                             float                       freq_scale,
+                             float                       attn_factor,
+                             bool                        is_neox) {
     // int sin/cos cache, cache has different repeat method depond on
     // @param.is_neox
     bool is_q = (std::strncmp(dst->name, "Qcur-", 5) == 0);
@@ -2274,55 +2675,53 @@ static void aclnn_cache_init(ggml_backend_cann_context& ctx, ggml_tensor* dst,
 
     // just compute in first layer in attention
     bool is_fisrt_layer = (std::strncmp(dst->name, "Qcur-0", GGML_MAX_NAME) == 0);
-    if(is_attention && !is_fisrt_layer) {
+    if (is_attention && !is_fisrt_layer) {
         return;
     }
 
-    ggml_tensor* src0 = dst->src[0];  // input
-    ggml_tensor* src1 = dst->src[1];  // position
-    ggml_tensor* src2 = dst->src[2];  // freq_factors
+    ggml_tensor * src0 = dst->src[0];  // input
+    ggml_tensor * src1 = dst->src[1];  // position
+    ggml_tensor * src2 = dst->src[2];  // freq_factors
 
     GGML_TENSOR_BINARY_OP_LOCALS
 
     int64_t theta_scale_length = ne00 / 2;
-    int64_t theta_scale_ne[] = {theta_scale_length, 1, 1, 1};
-    size_t theta_scale_nb[] = {sizeof(float_t), sizeof(float_t), sizeof(float_t),
-                          theta_scale_length * sizeof(float_t)};
+    int64_t theta_scale_ne[]   = { theta_scale_length, 1, 1, 1 };
+    size_t  theta_scale_nb[]   = {
+        sizeof(float_t), sizeof(float_t), sizeof(float_t), theta_scale_length * sizeof(float_t)
+    };
 
     GGML_ASSERT(src1->type == GGML_TYPE_I32);
     int64_t position_length = src1->ne[0];
-    int64_t position_ne[] = {1, 1, position_length, 1};
-    size_t position_nb[] = {sizeof(int32_t), sizeof(int32_t), sizeof(int32_t),
-                            sizeof(int32_t) * position_length};
+    int64_t position_ne[]   = { 1, 1, position_length, 1 };
+    size_t  position_nb[]   = { sizeof(int32_t), sizeof(int32_t), sizeof(int32_t), sizeof(int32_t) * position_length };
 
-    int64_t theta_ne[] = {theta_scale_length, 1, position_length, 1};
-    size_t theta_nb[GGML_MAX_DIMS];
+    int64_t theta_ne[] = { theta_scale_length, 1, position_length, 1 };
+    size_t  theta_nb[GGML_MAX_DIMS];
     theta_nb[0] = sizeof(float_t);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         theta_nb[i] = theta_nb[i - 1] * theta_ne[i - 1];
     }
 
     // init theta scale, just one time
-    if(ctx.rope_init_ptr == nullptr || !is_attention) {
+    if (ctx.rope_init_ptr == nullptr || !is_attention) {
         // theta_scale arange, [0,1,...,ne00/2 - 1]
-        if(ctx.rope_init_ptr != nullptr){
+        if (ctx.rope_init_ptr != nullptr) {
             ACL_CHECK(aclrtFree(ctx.rope_init_ptr));
         }
         ACL_CHECK(aclrtMalloc(&ctx.rope_init_ptr, theta_scale_length * sizeof(float_t), ACL_MEM_MALLOC_HUGE_FIRST));
 
-        aclTensor* acl_theta_scale_tensor =
-            ggml_cann_create_tensor(ctx.rope_init_ptr, ACL_FLOAT, sizeof(float_t),
-                                    theta_scale_ne, theta_scale_nb, GGML_MAX_DIMS);
-        float start = 0;
-        float step = 1;
-        float stop = ne00 / 2;
+        aclTensor * acl_theta_scale_tensor = ggml_cann_create_tensor(
+            ctx.rope_init_ptr, ACL_FLOAT, sizeof(float_t), theta_scale_ne, theta_scale_nb, GGML_MAX_DIMS);
+        float start      = 0;
+        float step       = 1;
+        float stop       = ne00 / 2;
         float n_elements = ne00 / 2;
         aclnn_arange(ctx, acl_theta_scale_tensor, start, stop, step, n_elements);
 
         // power
-        aclScalar* acl_theta_scale = aclCreateScalar(&theta_scale, aclDataType::ACL_FLOAT);
-        GGML_CANN_CALL_ACLNN_OP(ctx, PowScalarTensor, acl_theta_scale, acl_theta_scale_tensor,
-                                acl_theta_scale_tensor);
+        aclScalar * acl_theta_scale = aclCreateScalar(&theta_scale, aclDataType::ACL_FLOAT);
+        GGML_CANN_CALL_ACLNN_OP(ctx, PowScalarTensor, acl_theta_scale, acl_theta_scale_tensor, acl_theta_scale_tensor);
 
         // freq_scale
         if (freq_scale != 1) {
@@ -2331,21 +2730,24 @@ static void aclnn_cache_init(ggml_backend_cann_context& ctx, ggml_tensor* dst,
 
         // freq_factors
         if (src2) {
-            aclTensor* acl_freq_factors_tensor = ggml_cann_create_tensor(
-                src2->data, ggml_cann_type_mapping(src2->type),
-                ggml_type_size(src2->type), theta_scale_ne, theta_scale_nb, GGML_MAX_DIMS);
+            aclTensor * acl_freq_factors_tensor = ggml_cann_create_tensor(src2->data,
+                                                                          ggml_cann_type_mapping(src2->type),
+                                                                          ggml_type_size(src2->type),
+                                                                          theta_scale_ne,
+                                                                          theta_scale_nb,
+                                                                          GGML_MAX_DIMS);
             aclnn_div(ctx, acl_theta_scale_tensor, acl_freq_factors_tensor);
             ggml_cann_release_resources(ctx, acl_freq_factors_tensor);
         }
         // release
-        ggml_cann_release_resources(ctx, acl_theta_scale_tensor,acl_theta_scale);
+        ggml_cann_release_resources(ctx, acl_theta_scale_tensor, acl_theta_scale);
     }
 
     // init sin_repeat && cos_repeat, one token just init in 0 layer
-    if(position_length > ctx.max_prompt_length) {
-        ctx.max_prompt_length = position_length;
+    if (position_length > ctx.max_prompt_length) {
+        ctx.max_prompt_length       = position_length;
         int64_t repeat_theta_length = theta_scale_length * ctx.max_prompt_length * 2;
-        if(ctx.rope_sin_ptr != nullptr) {
+        if (ctx.rope_sin_ptr != nullptr) {
             ACL_CHECK(aclrtFree(ctx.rope_sin_ptr));
             ACL_CHECK(aclrtFree(ctx.rope_cos_ptr));
         }
@@ -2353,42 +2755,37 @@ static void aclnn_cache_init(ggml_backend_cann_context& ctx, ggml_tensor* dst,
         ACL_CHECK(aclrtMalloc(&ctx.rope_cos_ptr, repeat_theta_length * sizeof(float_t), ACL_MEM_MALLOC_HUGE_FIRST));
     }
 
-    aclTensor* acl_theta_scale_tensor =
-            ggml_cann_create_tensor(ctx.rope_init_ptr, ACL_FLOAT, sizeof(float_t),
-                                    theta_scale_ne, theta_scale_nb, GGML_MAX_DIMS);
+    aclTensor * acl_theta_scale_tensor = ggml_cann_create_tensor(
+        ctx.rope_init_ptr, ACL_FLOAT, sizeof(float_t), theta_scale_ne, theta_scale_nb, GGML_MAX_DIMS);
 
     // position
-    aclTensor* acl_position_tensor = ggml_cann_create_tensor(
-        src1->data, ggml_cann_type_mapping(src1->type),
-        ggml_type_size(src1->type), position_ne, position_nb, GGML_MAX_DIMS);
+    aclTensor * acl_position_tensor = ggml_cann_create_tensor(src1->data,
+                                                              ggml_cann_type_mapping(src1->type),
+                                                              ggml_type_size(src1->type),
+                                                              position_ne,
+                                                              position_nb,
+                                                              GGML_MAX_DIMS);
 
     // power * position
-    int64_t theta_length = theta_scale_length * position_length;
-    ggml_cann_pool_alloc theta_allocator(ctx.pool(),
-                                        theta_length * sizeof(float_t));
-    void* theta_buffer = theta_allocator.get();
+    int64_t              theta_length = theta_scale_length * position_length;
+    ggml_cann_pool_alloc theta_allocator(ctx.pool(), theta_length * sizeof(float_t));
+    void *               theta_buffer = theta_allocator.get();
 
-    aclTensor* acl_theta_tensor =
-        ggml_cann_create_tensor(theta_buffer, ACL_FLOAT, sizeof(float_t),
-                                theta_ne, theta_nb, GGML_MAX_DIMS);
-    aclnn_mul(ctx, acl_position_tensor, acl_theta_scale_tensor,
-            acl_theta_tensor);
+    aclTensor * acl_theta_tensor =
+        ggml_cann_create_tensor(theta_buffer, ACL_FLOAT, sizeof(float_t), theta_ne, theta_nb, GGML_MAX_DIMS);
+    aclnn_mul(ctx, acl_position_tensor, acl_theta_scale_tensor, acl_theta_tensor);
 
     // sin/cos
-    ggml_cann_pool_alloc sin_allocator(ctx.pool(),
-                                    theta_length * sizeof(float_t));
-    void* sin_buffer = sin_allocator.get();
-    aclTensor* acl_sin_tensor = ggml_cann_create_tensor(
-        sin_buffer, ACL_FLOAT, sizeof(float_t), theta_ne, theta_nb,
-        GGML_MAX_DIMS, ACL_FORMAT_ND);
+    ggml_cann_pool_alloc sin_allocator(ctx.pool(), theta_length * sizeof(float_t));
+    void *               sin_buffer     = sin_allocator.get();
+    aclTensor *          acl_sin_tensor = ggml_cann_create_tensor(
+        sin_buffer, ACL_FLOAT, sizeof(float_t), theta_ne, theta_nb, GGML_MAX_DIMS, ACL_FORMAT_ND);
     aclnn_sin(ctx, acl_theta_tensor, acl_sin_tensor);
 
-    ggml_cann_pool_alloc cos_allocator(ctx.pool(),
-                                    theta_length * sizeof(float_t));
-    void* cos_buffer = cos_allocator.get();
-    aclTensor* acl_cos_tensor = ggml_cann_create_tensor(
-        cos_buffer, ACL_FLOAT, sizeof(float_t), theta_ne, theta_nb,
-        GGML_MAX_DIMS, ACL_FORMAT_ND);
+    ggml_cann_pool_alloc cos_allocator(ctx.pool(), theta_length * sizeof(float_t));
+    void *               cos_buffer     = cos_allocator.get();
+    aclTensor *          acl_cos_tensor = ggml_cann_create_tensor(
+        cos_buffer, ACL_FLOAT, sizeof(float_t), theta_ne, theta_nb, GGML_MAX_DIMS, ACL_FORMAT_ND);
     aclnn_cos(ctx, acl_theta_tensor, acl_cos_tensor);
 
     // attn_factor
@@ -2397,75 +2794,79 @@ static void aclnn_cache_init(ggml_backend_cann_context& ctx, ggml_tensor* dst,
         aclnn_muls(ctx, acl_cos_tensor, attn_factor, nullptr, true);
     }
 
-    int64_t sin_reshape_ne[4] = {ne00, 1, ne02, 1};
-    size_t sin_reshape_nb[GGML_MAX_DIMS];
+    int64_t sin_reshape_ne[4] = { ne00, 1, ne02, 1 };
+    size_t  sin_reshape_nb[GGML_MAX_DIMS];
     sin_reshape_nb[0] = sizeof(float_t);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         sin_reshape_nb[i] = sin_reshape_nb[i - 1] * sin_reshape_ne[i - 1];
     }
-    aclTensor* acl_sin_repeat_tensor =
-        ggml_cann_create_tensor(ctx.rope_sin_ptr, ACL_FLOAT, sizeof(float_t),
-                                sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
-    aclTensor* acl_cos_repeat_tensor =
-        ggml_cann_create_tensor(ctx.rope_cos_ptr, ACL_FLOAT, sizeof(float_t),
-                                sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
+    aclTensor * acl_sin_repeat_tensor = ggml_cann_create_tensor(
+        ctx.rope_sin_ptr, ACL_FLOAT, sizeof(float_t), sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
+    aclTensor * acl_cos_repeat_tensor = ggml_cann_create_tensor(
+        ctx.rope_cos_ptr, ACL_FLOAT, sizeof(float_t), sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
 
     // repeat
     if (is_neox) {
-        int64_t repeatsArray[] = {1, 1, 1, 2};
+        int64_t repeatsArray[] = { 1, 1, 1, 2 };
         aclnn_repeat(ctx, acl_sin_tensor, acl_sin_repeat_tensor, repeatsArray);
         aclnn_repeat(ctx, acl_cos_tensor, acl_cos_repeat_tensor, repeatsArray);
     } else {
         int64_t num_repeats = 2;
-        int64_t dim = 3;
+        int64_t dim         = 3;
         int64_t output_size = theta_scale_length * num_repeats;
-        aclnn_repeat_interleave(ctx, acl_sin_tensor, acl_sin_repeat_tensor, dim,
-                                num_repeats, output_size);
-        aclnn_repeat_interleave(ctx, acl_cos_tensor, acl_cos_repeat_tensor, dim,
-                                num_repeats, output_size);
+        aclnn_repeat_interleave(ctx, acl_sin_tensor, acl_sin_repeat_tensor, dim, num_repeats, output_size);
+        aclnn_repeat_interleave(ctx, acl_cos_tensor, acl_cos_repeat_tensor, dim, num_repeats, output_size);
     }
 
-    ggml_cann_release_resources(ctx, acl_theta_scale_tensor, acl_position_tensor,
-        acl_theta_tensor, acl_sin_tensor, acl_sin_repeat_tensor, acl_cos_tensor,
-        acl_cos_repeat_tensor);
+    ggml_cann_release_resources(ctx,
+                                acl_theta_scale_tensor,
+                                acl_position_tensor,
+                                acl_theta_tensor,
+                                acl_sin_tensor,
+                                acl_sin_repeat_tensor,
+                                acl_cos_tensor,
+                                acl_cos_repeat_tensor);
 }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-aclnnStatus aclnnRotaryPositionEmbeddingGetWorkspaceSize(
-    const aclTensor* x, const aclTensor* cos, const aclTensor* sin,
-    int64_t mode, const aclTensor* yOut, uint64_t* workspaceSize,
-    aclOpExecutor** executor);
-aclnnStatus aclnnRotaryPositionEmbedding(void* workspace,
-                                         uint64_t workspaceSize,
-                                         aclOpExecutor* executor,
-                                         aclrtStream stream);
+aclnnStatus aclnnRotaryPositionEmbeddingGetWorkspaceSize(const aclTensor * x,
+                                                         const aclTensor * cos,
+                                                         const aclTensor * sin,
+                                                         int64_t           mode,
+                                                         const aclTensor * yOut,
+                                                         uint64_t *        workspaceSize,
+                                                         aclOpExecutor **  executor);
+aclnnStatus aclnnRotaryPositionEmbedding(void *          workspace,
+                                         uint64_t        workspaceSize,
+                                         aclOpExecutor * executor,
+                                         aclrtStream     stream);
 #ifdef __cplusplus
 }
 #endif
 
-void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
+void ggml_cann_rope(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     // TODO: use ascendc
     // Only test with LLAMA model.
-    ggml_tensor* src0 = dst->src[0];  // input
+    ggml_tensor * src0 = dst->src[0];  // input
 
     // param
-    float freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow;
+    float     freq_base, freq_scale, ext_factor, attn_factor, beta_fast, beta_slow;
     // const int n_past     = ((int32_t *) dst->op_params)[0];
-    const int n_dims = ((int32_t*)dst->op_params)[1];
-    const int mode = ((int32_t*)dst->op_params)[2];
+    const int n_dims     = ((int32_t *) dst->op_params)[1];
+    const int mode       = ((int32_t *) dst->op_params)[2];
     // const int n_ctx      = ((int32_t *) dst->op_params)[3];
-    const int n_ctx_orig = ((int32_t*)dst->op_params)[4];
+    const int n_ctx_orig = ((int32_t *) dst->op_params)[4];
 
     GGML_TENSOR_UNARY_OP_LOCALS
 
-    memcpy(&freq_base, (int32_t*)dst->op_params + 5, sizeof(float));
-    memcpy(&freq_scale, (int32_t*)dst->op_params + 6, sizeof(float));
-    memcpy(&ext_factor, (int32_t*)dst->op_params + 7, sizeof(float));
-    memcpy(&attn_factor, (int32_t*)dst->op_params + 8, sizeof(float));
-    memcpy(&beta_fast, (int32_t*)dst->op_params + 9, sizeof(float));
-    memcpy(&beta_slow, (int32_t*)dst->op_params + 10, sizeof(float));
+    memcpy(&freq_base, (int32_t *) dst->op_params + 5, sizeof(float));
+    memcpy(&freq_scale, (int32_t *) dst->op_params + 6, sizeof(float));
+    memcpy(&ext_factor, (int32_t *) dst->op_params + 7, sizeof(float));
+    memcpy(&attn_factor, (int32_t *) dst->op_params + 8, sizeof(float));
+    memcpy(&beta_fast, (int32_t *) dst->op_params + 9, sizeof(float));
+    memcpy(&beta_slow, (int32_t *) dst->op_params + 10, sizeof(float));
 
     // TODO: n_dims <= ne0
     GGML_ASSERT(n_dims == ne0);
@@ -2476,122 +2877,132 @@ void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     const float theta_scale = powf(freq_base, -2.0f / n_dims);
 
     float corr_dims[2];
-    ggml_rope_yarn_corr_dims(n_dims, n_ctx_orig, freq_base, beta_fast,
-                             beta_slow, corr_dims);
+    ggml_rope_yarn_corr_dims(n_dims, n_ctx_orig, freq_base, beta_fast, beta_slow, corr_dims);
 
     const bool is_neox = mode & GGML_ROPE_TYPE_NEOX;
 
     // init ctx.rope_cos/rope_sin cache
     aclnn_cache_init(ctx, dst, theta_scale, freq_scale, attn_factor, is_neox);
 
-    int64_t sin_reshape_ne[4] = {ne00, 1, ne02, 1};
-    size_t sin_reshape_nb[GGML_MAX_DIMS];
+    int64_t sin_reshape_ne[4] = { ne00, 1, ne02, 1 };
+    size_t  sin_reshape_nb[GGML_MAX_DIMS];
     sin_reshape_nb[0] = sizeof(float_t);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         sin_reshape_nb[i] = sin_reshape_nb[i - 1] * sin_reshape_ne[i - 1];
     }
-    aclTensor* acl_sin_reshape_tensor =
-        ggml_cann_create_tensor(ctx.rope_sin_ptr, ACL_FLOAT, sizeof(float_t),
-                                sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
-    aclTensor* acl_cos_reshape_tensor =
-        ggml_cann_create_tensor(ctx.rope_cos_ptr, ACL_FLOAT, sizeof(float_t),
-                                sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
+    aclTensor * acl_sin_reshape_tensor = ggml_cann_create_tensor(
+        ctx.rope_sin_ptr, ACL_FLOAT, sizeof(float_t), sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
+    aclTensor * acl_cos_reshape_tensor = ggml_cann_create_tensor(
+        ctx.rope_cos_ptr, ACL_FLOAT, sizeof(float_t), sin_reshape_ne, sin_reshape_nb, GGML_MAX_DIMS);
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src0);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
 #ifdef ASCEND_310P
     // Special ROPE operation for 310P
 
     // roll input
-    void* input_roll_buffer;
-    aclTensor* acl_minus_one_tensor;
-    void* minus_one_scale_buffer = nullptr;
+    void *               input_roll_buffer;
+    aclTensor *          acl_minus_one_tensor;
+    void *               minus_one_scale_buffer = nullptr;
     ggml_cann_pool_alloc roll_allocator(ctx.pool(), ggml_nbytes(src0));
-    ggml_cann_pool_alloc minus_one_scale_allocator(
-        ctx.pool(), sizeof(float_t) * src0->ne[0]);
+    ggml_cann_pool_alloc minus_one_scale_allocator(ctx.pool(), sizeof(float_t) * src0->ne[0]);
     if (!is_neox) {
         // roll input: [q0,q1,q2,q3,...] -> [q1,q0,q3,q2,...]
-        input_roll_buffer = roll_allocator.get();
-        int64_t input_roll_ne[4] = {2, src0->ne[1] * (src0->ne[0] / 2),
-                                    src0->ne[2], src0->ne[3]};
-        size_t input_roll_nb[GGML_MAX_DIMS];
+        input_roll_buffer        = roll_allocator.get();
+        int64_t input_roll_ne[4] = { 2, src0->ne[1] * (src0->ne[0] / 2), src0->ne[2], src0->ne[3] };
+        size_t  input_roll_nb[GGML_MAX_DIMS];
         input_roll_nb[0] = ggml_type_size(src0->type);
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             input_roll_nb[i] = input_roll_nb[i - 1] * input_roll_ne[i - 1];
         }
-        aclTensor* acl_input_roll_tensor = ggml_cann_create_tensor(
-            input_roll_buffer, ggml_cann_type_mapping(src0->type),
-            ggml_type_size(src0->type), input_roll_ne, input_roll_nb,
-            GGML_MAX_DIMS);
-        aclTensor* acl_input_tensor = ggml_cann_create_tensor(
-            src0->data, ggml_cann_type_mapping(src0->type),
-            ggml_type_size(src0->type), input_roll_ne, input_roll_nb,
-            GGML_MAX_DIMS);
+        aclTensor * acl_input_roll_tensor = ggml_cann_create_tensor(input_roll_buffer,
+                                                                    ggml_cann_type_mapping(src0->type),
+                                                                    ggml_type_size(src0->type),
+                                                                    input_roll_ne,
+                                                                    input_roll_nb,
+                                                                    GGML_MAX_DIMS);
+        aclTensor * acl_input_tensor      = ggml_cann_create_tensor(src0->data,
+                                                               ggml_cann_type_mapping(src0->type),
+                                                               ggml_type_size(src0->type),
+                                                               input_roll_ne,
+                                                               input_roll_nb,
+                                                               GGML_MAX_DIMS);
 
-        int64_t shifts[] = {1};
-        int64_t dims[] = {3};
+        int64_t shifts[] = { 1 };
+        int64_t dims[]   = { 3 };
         aclnn_roll(ctx, acl_input_tensor, acl_input_roll_tensor, shifts, dims);
         ggml_cann_release_resources(ctx, acl_input_roll_tensor, acl_input_tensor);
 
         // init [-1, 1, -1, 1, ...]
         minus_one_scale_buffer = minus_one_scale_allocator.get();
 
-        int64_t minus_one_ne[4] = {src0->ne[0], 1, 1, 1};
-        size_t minus_one_nb[GGML_MAX_DIMS];
+        int64_t minus_one_ne[4] = { src0->ne[0], 1, 1, 1 };
+        size_t  minus_one_nb[GGML_MAX_DIMS];
         minus_one_nb[0] = sizeof(float_t);
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             minus_one_nb[i] = minus_one_nb[i - 1] * minus_one_ne[i - 1];
         }
-        acl_minus_one_tensor = aclnn_values(
-            ctx, minus_one_scale_buffer, sizeof(float_t) * src0->ne[0],
-            minus_one_ne, GGML_MAX_DIMS, ACL_FLOAT, sizeof(float_t), 1);
-        int64_t dim = 3;
-        int64_t* index = new int64_t[src0->ne[0]];
+        acl_minus_one_tensor = aclnn_values(ctx,
+                                            minus_one_scale_buffer,
+                                            sizeof(float_t) * src0->ne[0],
+                                            minus_one_ne,
+                                            GGML_MAX_DIMS,
+                                            ACL_FLOAT,
+                                            sizeof(float_t),
+                                            1);
+        int64_t   dim        = 3;
+        int64_t * index      = new int64_t[src0->ne[0]];
         for (int i = 0; i < src0->ne[0]; i++) {
             index[i] = i / 2 * 2;
         }
         int64_t index_num = src0->ne[0];
-        float value = -1;
-        aclnn_index_fill_tensor(ctx, acl_minus_one_tensor, dim, index,
-                                index_num, value);
+        float   value     = -1;
+        aclnn_index_fill_tensor(ctx, acl_minus_one_tensor, dim, index, index_num, value);
     } else {
         // roll input: [q0,q1,q2,...] ->
         // [q_half,q_half+1,...,q_end,q0,q1,...q_half-1]
-        input_roll_buffer = roll_allocator.get();
-        aclTensor* acl_input_roll_tensor = ggml_cann_create_tensor(
-            input_roll_buffer, ggml_cann_type_mapping(src0->type),
-            ggml_type_size(src0->type), src0->ne, src0->nb, GGML_MAX_DIMS);
-        aclTensor* acl_input_tensor = ggml_cann_create_tensor(src0);
+        input_roll_buffer                 = roll_allocator.get();
+        aclTensor * acl_input_roll_tensor = ggml_cann_create_tensor(input_roll_buffer,
+                                                                    ggml_cann_type_mapping(src0->type),
+                                                                    ggml_type_size(src0->type),
+                                                                    src0->ne,
+                                                                    src0->nb,
+                                                                    GGML_MAX_DIMS);
+        aclTensor * acl_input_tensor      = ggml_cann_create_tensor(src0);
 
-        int64_t shifts[] = {src0->ne[0] / 2};
-        int64_t dims[] = {3};
+        int64_t shifts[] = { src0->ne[0] / 2 };
+        int64_t dims[]   = { 3 };
         aclnn_roll(ctx, acl_input_tensor, acl_input_roll_tensor, shifts, dims);
 
         ggml_cann_release_resources(ctx, acl_input_roll_tensor, acl_input_tensor);
         // init [-1, -1, -1, 1, 1，1，...]
-        minus_one_scale_buffer = minus_one_scale_allocator.get();
-        int64_t minus_one_ne[4] = {src0->ne[0], 1, 1, 1};
-        size_t minus_one_nb[GGML_MAX_DIMS];
+        minus_one_scale_buffer  = minus_one_scale_allocator.get();
+        int64_t minus_one_ne[4] = { src0->ne[0], 1, 1, 1 };
+        size_t  minus_one_nb[GGML_MAX_DIMS];
         minus_one_nb[0] = sizeof(float_t);
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             minus_one_nb[i] = minus_one_nb[i - 1] * minus_one_ne[i - 1];
         }
-        acl_minus_one_tensor = aclnn_values(
-            ctx, minus_one_scale_buffer, sizeof(float_t) * src0->ne[0],
-            minus_one_ne, GGML_MAX_DIMS, ACL_FLOAT, sizeof(float_t), 1);
+        acl_minus_one_tensor     = aclnn_values(ctx,
+                                            minus_one_scale_buffer,
+                                            sizeof(float_t) * src0->ne[0],
+                                            minus_one_ne,
+                                            GGML_MAX_DIMS,
+                                            ACL_FLOAT,
+                                            sizeof(float_t),
+                                            1);
         // -1 * first half
-        int64_t first_half_ne[4] = {src0->ne[0] / 2, 1, 1, 1};
-        size_t first_half_nb[GGML_MAX_DIMS];
+        int64_t first_half_ne[4] = { src0->ne[0] / 2, 1, 1, 1 };
+        size_t  first_half_nb[GGML_MAX_DIMS];
         first_half_nb[0] = sizeof(float_t);
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             first_half_nb[i] = first_half_nb[i - 1] * first_half_ne[i - 1];
         }
-        aclTensor* acl_first_half_tensor = ggml_cann_create_tensor(
-            minus_one_scale_buffer, ACL_FLOAT, sizeof(float_t), first_half_ne,
-            first_half_nb, GGML_MAX_DIMS);
-        bool inplace = true;
-        float scale = -1;
+        aclTensor * acl_first_half_tensor = ggml_cann_create_tensor(
+            minus_one_scale_buffer, ACL_FLOAT, sizeof(float_t), first_half_ne, first_half_nb, GGML_MAX_DIMS);
+        bool  inplace = true;
+        float scale   = -1;
         aclnn_muls(ctx, acl_first_half_tensor, scale, nullptr, inplace);
         ggml_cann_release_resources(ctx, acl_first_half_tensor);
     }
@@ -2600,30 +3011,33 @@ void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     GGML_ASSERT(n_dims == src0->ne[0]);
 
     // input * scale
-    ggml_cann_pool_alloc roll_mul_scale_allocator(ctx.pool(),
-                                                  ggml_nbytes(src0));
-    void* input_roll_mul_scale_buffer = roll_mul_scale_allocator.get();
-    size_t input_nb[GGML_MAX_DIMS];
+    ggml_cann_pool_alloc roll_mul_scale_allocator(ctx.pool(), ggml_nbytes(src0));
+    void *               input_roll_mul_scale_buffer = roll_mul_scale_allocator.get();
+    size_t               input_nb[GGML_MAX_DIMS];
     input_nb[0] = ggml_type_size(src0->type);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         input_nb[i] = input_nb[i - 1] * src0->ne[i - 1];
     }
-    aclTensor* acl_input_roll_mul_scale_tensor = ggml_cann_create_tensor(
-        input_roll_mul_scale_buffer, ggml_cann_type_mapping(src0->type),
-        ggml_type_size(src0->type), src0->ne, input_nb, GGML_MAX_DIMS);
-    aclTensor* acl_input_roll_reshape_tensor = ggml_cann_create_tensor(
-        input_roll_buffer, ggml_cann_type_mapping(src0->type),
-        ggml_type_size(src0->type), src0->ne, input_nb, GGML_MAX_DIMS);
+    aclTensor * acl_input_roll_mul_scale_tensor = ggml_cann_create_tensor(input_roll_mul_scale_buffer,
+                                                                          ggml_cann_type_mapping(src0->type),
+                                                                          ggml_type_size(src0->type),
+                                                                          src0->ne,
+                                                                          input_nb,
+                                                                          GGML_MAX_DIMS);
+    aclTensor * acl_input_roll_reshape_tensor   = ggml_cann_create_tensor(input_roll_buffer,
+                                                                        ggml_cann_type_mapping(src0->type),
+                                                                        ggml_type_size(src0->type),
+                                                                        src0->ne,
+                                                                        input_nb,
+                                                                        GGML_MAX_DIMS);
 
-    aclnn_mul(ctx, acl_input_roll_reshape_tensor, acl_minus_one_tensor,
-              acl_input_roll_mul_scale_tensor);
+    aclnn_mul(ctx, acl_input_roll_reshape_tensor, acl_minus_one_tensor, acl_input_roll_mul_scale_tensor);
 
     // output
-    void* output_fp32_buffer;
+    void * output_fp32_buffer;
     if (src0->type == GGML_TYPE_F32) {
         aclnn_mul(ctx, acl_src, acl_cos_reshape_tensor);
-        aclnn_mul(ctx, acl_input_roll_mul_scale_tensor,
-                          acl_sin_reshape_tensor);
+        aclnn_mul(ctx, acl_input_roll_mul_scale_tensor, acl_sin_reshape_tensor);
         aclnn_add(ctx, acl_src, acl_input_roll_mul_scale_tensor, acl_dst);
         // TODO: ne0 != n_dims in mode2
     } else if (src0->type == GGML_TYPE_F16) {
@@ -2632,36 +3046,33 @@ void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
         for (int i = 1; i < GGML_MAX_DIMS; i++) {
             input_fp32_nb[i] = input_fp32_nb[i - 1] * dst->ne[i - 1];
         }
-        ggml_cann_pool_alloc fp32_allocator1(
-            ctx.pool(), ggml_nelements(dst) * sizeof(float_t));
-        void* input_fp32_buffer1 = fp32_allocator1.get();
-        aclTensor* input_fp32_tensor1 = ggml_cann_create_tensor(
-            input_fp32_buffer1, ACL_FLOAT, sizeof(float_t), dst->ne,
-            input_fp32_nb, GGML_MAX_DIMS);
-        ggml_cann_pool_alloc fp32_allocator2(
-            ctx.pool(), ggml_nelements(dst) * sizeof(float_t));
-        void* input_fp32_buffer2 = fp32_allocator2.get();
-        aclTensor* input_fp32_tensor2 = ggml_cann_create_tensor(
-            input_fp32_buffer2, ACL_FLOAT, sizeof(float_t), dst->ne,
-            input_fp32_nb, GGML_MAX_DIMS);
+        ggml_cann_pool_alloc fp32_allocator1(ctx.pool(), ggml_nelements(dst) * sizeof(float_t));
+        void *               input_fp32_buffer1 = fp32_allocator1.get();
+        aclTensor *          input_fp32_tensor1 = ggml_cann_create_tensor(
+            input_fp32_buffer1, ACL_FLOAT, sizeof(float_t), dst->ne, input_fp32_nb, GGML_MAX_DIMS);
+        ggml_cann_pool_alloc fp32_allocator2(ctx.pool(), ggml_nelements(dst) * sizeof(float_t));
+        void *               input_fp32_buffer2 = fp32_allocator2.get();
+        aclTensor *          input_fp32_tensor2 = ggml_cann_create_tensor(
+            input_fp32_buffer2, ACL_FLOAT, sizeof(float_t), dst->ne, input_fp32_nb, GGML_MAX_DIMS);
 
-        ggml_cann_pool_alloc fp32_allocator(
-            ctx.pool(), ggml_nelements(dst) * sizeof(float_t));
-        output_fp32_buffer = fp32_allocator.get();
-        aclTensor* output_fp32_tensor = ggml_cann_create_tensor(
-            output_fp32_buffer, ACL_FLOAT, sizeof(float_t), dst->ne,
-            input_fp32_nb, GGML_MAX_DIMS);
+        ggml_cann_pool_alloc fp32_allocator(ctx.pool(), ggml_nelements(dst) * sizeof(float_t));
+        output_fp32_buffer             = fp32_allocator.get();
+        aclTensor * output_fp32_tensor = ggml_cann_create_tensor(
+            output_fp32_buffer, ACL_FLOAT, sizeof(float_t), dst->ne, input_fp32_nb, GGML_MAX_DIMS);
         aclnn_mul(ctx, acl_src, acl_cos_reshape_tensor, input_fp32_tensor1);
-        aclnn_mul(ctx, acl_input_roll_mul_scale_tensor, acl_sin_reshape_tensor,
-                  input_fp32_tensor2);
-        aclnn_add(ctx, input_fp32_tensor1, input_fp32_tensor2,
-                  output_fp32_tensor);
+        aclnn_mul(ctx, acl_input_roll_mul_scale_tensor, acl_sin_reshape_tensor, input_fp32_tensor2);
+        aclnn_add(ctx, input_fp32_tensor1, input_fp32_tensor2, output_fp32_tensor);
         aclnn_cast(ctx, output_fp32_tensor, acl_dst, ACL_FLOAT16);
 
-        ggml_cann_release_resources(ctx, input_fp32_tensor1, input_fp32_tensor2,
-            output_fp32_tensor, acl_sin_reshape_tensor,
-            acl_minus_one_tensor, acl_input_roll_mul_scale_tensor,
-            acl_input_roll_reshape_tensor, acl_src);
+        ggml_cann_release_resources(ctx,
+                                    input_fp32_tensor1,
+                                    input_fp32_tensor2,
+                                    output_fp32_tensor,
+                                    acl_sin_reshape_tensor,
+                                    acl_minus_one_tensor,
+                                    acl_input_roll_mul_scale_tensor,
+                                    acl_input_roll_reshape_tensor,
+                                    acl_src);
     }
     return;
 #endif
@@ -2670,157 +3081,175 @@ void ggml_cann_rope(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     int64_t acl_mode = mode == 0 ? 1 : mode;
 
     switch (src0->type) {
-        case GGML_TYPE_F32: {
-            GGML_CANN_CALL_ACLNN_OP(ctx, RotaryPositionEmbedding, acl_src,
-                acl_cos_reshape_tensor, acl_sin_reshape_tensor, acl_mode, acl_dst);
-            break;
-        }
-        case GGML_TYPE_F16: {
-            ggml_cann_pool_alloc src_trans_allocator(
-                ctx.pool(), ggml_nelements(src0) * sizeof(float));
-            void* src_trans_buffer = src_trans_allocator.get();
-            ggml_cann_pool_alloc dst_trans_allocator(
-                ctx.pool(), ggml_nelements(dst) * sizeof(float));
-            void* dst_trans_buffer = dst_trans_allocator.get();
-
-            size_t src_trans_nb[GGML_MAX_DIMS];
-            src_trans_nb[0] = sizeof(float);
-            for (int i = 1; i < GGML_MAX_DIMS; i++) {
-                src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
+        case GGML_TYPE_F32:
+            {
+                GGML_CANN_CALL_ACLNN_OP(ctx,
+                                        RotaryPositionEmbedding,
+                                        acl_src,
+                                        acl_cos_reshape_tensor,
+                                        acl_sin_reshape_tensor,
+                                        acl_mode,
+                                        acl_dst);
+                break;
             }
+        case GGML_TYPE_F16:
+            {
+                ggml_cann_pool_alloc src_trans_allocator(ctx.pool(), ggml_nelements(src0) * sizeof(float));
+                void *               src_trans_buffer = src_trans_allocator.get();
+                ggml_cann_pool_alloc dst_trans_allocator(ctx.pool(), ggml_nelements(dst) * sizeof(float));
+                void *               dst_trans_buffer = dst_trans_allocator.get();
 
-            aclTensor* acl_src_trans_tensor = ggml_cann_create_tensor(
-                src_trans_buffer, ACL_FLOAT, sizeof(float), src0->ne, src_trans_nb,
-                GGML_MAX_DIMS);
-            aclTensor* acl_dst_trans_tensor = ggml_cann_create_tensor(
-                dst_trans_buffer, ACL_FLOAT, sizeof(float), dst->ne, src_trans_nb,
-                GGML_MAX_DIMS);
+                size_t src_trans_nb[GGML_MAX_DIMS];
+                src_trans_nb[0] = sizeof(float);
+                for (int i = 1; i < GGML_MAX_DIMS; i++) {
+                    src_trans_nb[i] = src_trans_nb[i - 1] * src0->ne[i - 1];
+                }
 
-            aclnn_cast(ctx, acl_src, acl_src_trans_tensor, ACL_FLOAT);
+                aclTensor * acl_src_trans_tensor = ggml_cann_create_tensor(
+                    src_trans_buffer, ACL_FLOAT, sizeof(float), src0->ne, src_trans_nb, GGML_MAX_DIMS);
+                aclTensor * acl_dst_trans_tensor = ggml_cann_create_tensor(
+                    dst_trans_buffer, ACL_FLOAT, sizeof(float), dst->ne, src_trans_nb, GGML_MAX_DIMS);
 
-            GGML_CANN_CALL_ACLNN_OP(ctx, RotaryPositionEmbedding, acl_src_trans_tensor,
-                acl_cos_reshape_tensor, acl_sin_reshape_tensor, acl_mode,
-                acl_dst_trans_tensor);
+                aclnn_cast(ctx, acl_src, acl_src_trans_tensor, ACL_FLOAT);
 
-            aclnn_cast(ctx, acl_dst_trans_tensor, acl_dst, ACL_FLOAT16);
+                GGML_CANN_CALL_ACLNN_OP(ctx,
+                                        RotaryPositionEmbedding,
+                                        acl_src_trans_tensor,
+                                        acl_cos_reshape_tensor,
+                                        acl_sin_reshape_tensor,
+                                        acl_mode,
+                                        acl_dst_trans_tensor);
 
-            ggml_cann_release_resources(ctx, acl_src_trans_tensor,
-                acl_dst_trans_tensor);
-            break;
-        }
+                aclnn_cast(ctx, acl_dst_trans_tensor, acl_dst, ACL_FLOAT16);
+
+                ggml_cann_release_resources(ctx, acl_src_trans_tensor, acl_dst_trans_tensor);
+                break;
+            }
         default:
             GGML_ABORT("Unsupported tensor type for GGML_OP_ROPE");
             break;
     }
-    ggml_cann_release_resources(ctx, acl_cos_reshape_tensor,
-        acl_sin_reshape_tensor, acl_src, acl_dst);
+    ggml_cann_release_resources(ctx, acl_cos_reshape_tensor, acl_sin_reshape_tensor, acl_src, acl_dst);
 }
 
-
- void ggml_cann_argmax(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_argmax(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     ggml_tensor * src0 = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst, dst->ne, dst->nb, 3);
+    aclTensor * acl_src = ggml_cann_create_tensor(src0);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst, dst->ne, dst->nb, 3);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, ArgMax, acl_src, 3, false, acl_dst);
 
     ggml_cann_release_resources(ctx, acl_src, acl_dst);
 }
 
-void ggml_cann_conv_transpose_1d(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_conv_transpose_1d(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     ggml_tensor * src0 = dst->src[0];
     ggml_tensor * src1 = dst->src[1];
 
     // stride
-    int64_t s0 = ((const int32_t*)(dst->op_params))[0];
+    int64_t s0 = ((const int32_t *) (dst->op_params))[0];
 
-    aclTensor* acl_input = ggml_cann_create_tensor(src1, src1->ne, src1->nb, 3, ACL_FORMAT_NCL);
-    aclTensor* acl_weight = ggml_cann_create_tensor(src0, src0->ne, src0->nb, 3, ACL_FORMAT_NCL);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst, dst->ne, dst->nb, 3, ACL_FORMAT_NCL);
+    aclTensor * acl_input  = ggml_cann_create_tensor(src1, src1->ne, src1->nb, 3, ACL_FORMAT_NCL);
+    aclTensor * acl_weight = ggml_cann_create_tensor(src0, src0->ne, src0->nb, 3, ACL_FORMAT_NCL);
+    aclTensor * acl_dst    = ggml_cann_create_tensor(dst, dst->ne, dst->nb, 3, ACL_FORMAT_NCL);
 
     int64_t strideVal[1];
-    strideVal[0] = s0;
-    aclIntArray *stride = aclCreateIntArray(strideVal, 1);
-    int64_t paddingVal[] = {0};
-    aclIntArray *padding = aclCreateIntArray(paddingVal, 1);
-    int64_t dilationVal[] = {1};
-    aclIntArray *dilation = aclCreateIntArray(dilationVal, 1);
-    bool transposed = true;
-    int64_t groups = 1;
-    int8_t cubeMathType = 0;
+    strideVal[0]                = s0;
+    aclIntArray * stride        = aclCreateIntArray(strideVal, 1);
+    int64_t       paddingVal[]  = { 0 };
+    aclIntArray * padding       = aclCreateIntArray(paddingVal, 1);
+    int64_t       dilationVal[] = { 1 };
+    aclIntArray * dilation      = aclCreateIntArray(dilationVal, 1);
+    bool          transposed    = true;
+    int64_t       groups        = 1;
+    int8_t        cubeMathType  = 0;
 
 #ifdef ASCEND_310P
     cubeMathType = 1;
 #endif
 
-    GGML_CANN_CALL_ACLNN_OP(ctx, Convolution, acl_input, acl_weight, nullptr, stride,
-        padding, dilation, transposed, padding, groups, acl_dst, cubeMathType);
+    GGML_CANN_CALL_ACLNN_OP(ctx,
+                            Convolution,
+                            acl_input,
+                            acl_weight,
+                            nullptr,
+                            stride,
+                            padding,
+                            dilation,
+                            transposed,
+                            padding,
+                            groups,
+                            acl_dst,
+                            cubeMathType);
 
     ggml_cann_release_resources(ctx, acl_weight, acl_dst, stride, padding, dilation);
 }
 
-void ggml_cann_elu(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_elu(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     ggml_tensor * src0 = dst->src[0];
 
-    aclTensor* acl_input = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_input = ggml_cann_create_tensor(src0);
+    aclTensor * acl_dst   = ggml_cann_create_tensor(dst);
 
-    float alphaValue = 1.0f;
-    aclScalar* alpha = nullptr;
-    alpha = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
+    float       alphaValue = 1.0f;
+    aclScalar * alpha      = nullptr;
+    alpha                  = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
 
-    GGML_CANN_CALL_ACLNN_OP(ctx, Elu, acl_input, alpha, alpha, alpha,
-        acl_dst);
+    GGML_CANN_CALL_ACLNN_OP(ctx, Elu, acl_input, alpha, alpha, alpha, acl_dst);
 
     ggml_cann_release_resources(ctx, acl_input, acl_dst, alpha);
 }
 
-void ggml_cann_mean(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_mean(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     ggml_tensor * src0 = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src0);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
-    int64_t reduceDimValue[] = {3};
-    aclIntArray* reduceDim = aclCreateIntArray(reduceDimValue, 1);
-    bool keepDim = true;
+    int64_t       reduceDimValue[] = { 3 };
+    aclIntArray * reduceDim        = aclCreateIntArray(reduceDimValue, 1);
+    bool          keepDim          = true;
 
     GGML_CANN_CALL_ACLNN_OP(ctx, Mean, acl_src, reduceDim, keepDim, ACL_FLOAT, acl_dst);
 
     ggml_cann_release_resources(ctx, acl_src, acl_dst, reduceDim);
 }
 
-void ggml_cann_pad_reflect_1d(ggml_backend_cann_context& ctx, ggml_tensor* dst){
-    ggml_tensor * src0 = dst->src[0];
-    int32_t *opts = (int32_t *) dst->op_params;
-    int64_t paddingsArray[2] = {opts[0], opts[1]};
-    aclIntArray* paddings = aclCreateIntArray(paddingsArray, 2);
+void ggml_cann_pad_reflect_1d(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0             = dst->src[0];
+    int32_t *     opts             = (int32_t *) dst->op_params;
+    int64_t       paddingsArray[2] = { opts[0], opts[1] };
+    aclIntArray * paddings         = aclCreateIntArray(paddingsArray, 2);
 
     for (int64_t i = 0; i < src0->ne[3]; i++) {
-        aclTensor* acl_src = ggml_cann_create_tensor(
-            (char*)src0->data + i * src0->ne[3],
-            ggml_cann_type_mapping(src0->type), ggml_element_size(src0),
-            src0->ne, src0->nb, 3);
+        aclTensor * acl_src = ggml_cann_create_tensor((char *) src0->data + i * src0->ne[3],
+                                                      ggml_cann_type_mapping(src0->type),
+                                                      ggml_element_size(src0),
+                                                      src0->ne,
+                                                      src0->nb,
+                                                      3);
 
-        aclTensor* acl_dst = ggml_cann_create_tensor(
-            (char*)dst->data + i * src0->ne[3],
-            ggml_cann_type_mapping(dst->type), ggml_element_size(dst),
-            dst->ne, dst->nb, 3);
+        aclTensor * acl_dst = ggml_cann_create_tensor((char *) dst->data + i * src0->ne[3],
+                                                      ggml_cann_type_mapping(dst->type),
+                                                      ggml_element_size(dst),
+                                                      dst->ne,
+                                                      dst->nb,
+                                                      3);
 
-            GGML_CANN_CALL_ACLNN_OP(ctx, ReflectionPad1d, acl_src, paddings, acl_dst);
+        GGML_CANN_CALL_ACLNN_OP(ctx, ReflectionPad1d, acl_src, paddings, acl_dst);
 
-            ggml_cann_release_resources(ctx, acl_src, acl_dst);
+        ggml_cann_release_resources(ctx, acl_src, acl_dst);
     }
     ggml_cann_release_resources(ctx, paddings);
 }
 
-void ggml_cann_count_equal(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_count_equal(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     ggml_tensor * src0 = dst->src[0];
     ggml_tensor * src1 = dst->src[1];
 
-    aclTensor* acl_self = ggml_cann_create_tensor(src0);
-    aclTensor* acl_other = ggml_cann_create_tensor(src1);
+    aclTensor * acl_self  = ggml_cann_create_tensor(src0);
+    aclTensor * acl_other = ggml_cann_create_tensor(src1);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, InplaceEqTensor, acl_self, acl_other);
 
@@ -2829,15 +3258,15 @@ void ggml_cann_count_equal(ggml_backend_cann_context& ctx, ggml_tensor* dst){
     ggml_cann_release_resources(ctx, acl_self, acl_other);
 }
 
-void ggml_cann_step(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_step(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     ggml_tensor * src0 = dst->src[0];
 
-    aclTensor* acl_src = ggml_cann_create_tensor(src0);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
+    aclTensor * acl_src = ggml_cann_create_tensor(src0);
+    aclTensor * acl_dst = ggml_cann_create_tensor(dst);
 
-    float alphaValue = 0.0f;
-    aclScalar* alpha = nullptr;
-    alpha = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
+    float       alphaValue = 0.0f;
+    aclScalar * alpha      = nullptr;
+    alpha                  = aclCreateScalar(&alphaValue, aclDataType::ACL_FLOAT);
 
     GGML_CANN_CALL_ACLNN_OP(ctx, GtScalar, acl_src, alpha, acl_dst);
 
@@ -2862,7 +3291,7 @@ void ggml_cann_step(ggml_backend_cann_context& ctx, ggml_tensor* dst){
  * @note This function assumes floating-point data types and is designed for
  * MoE architectures, possibly involving sparse expert routing.
  */
-static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
+static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     //dst   [M, K, N, 1]
     ggml_tensor * src0 = dst->src[0];  //src0	[D, M, A, 1]
     ggml_tensor * src1 = dst->src[1];  //src1	[D, B, N, 1], B = K or B = 1
@@ -2871,24 +3300,23 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
     GGML_TENSOR_BINARY_OP_LOCALS
 
     // copy index from npu to cpu
-    int64_t n_as = ne02; // A
-    int64_t n_ids = ids->ne[0]; // K
+    int64_t n_as  = ne02;        // A
+    int64_t n_ids = ids->ne[0];  // K
 
     std::vector<char> ids_host(ggml_nbytes(ids));
-    ggml_cann_async_memcpy(ctx, ids_host.data(), ids->data, ggml_nbytes(ids),
-        ACL_MEMCPY_DEVICE_TO_HOST);
+    ggml_cann_async_memcpy(ctx, ids_host.data(), ids->data, ggml_nbytes(ids), ACL_MEMCPY_DEVICE_TO_HOST);
     ACL_CHECK(aclrtSynchronizeStream(ctx.stream()));
 
-    char * src0_original = (char *) src0->data;
-    char * src1_original = (char *) src1->data;
-    char * dst_original  = (char *)  dst->data;
-    size_t ori_src0_nb[4] = {nb00, nb01, nb02, nb03};
+    char * src0_original  = (char *) src0->data;
+    char * src1_original  = (char *) src1->data;
+    char * dst_original   = (char *) dst->data;
+    size_t ori_src0_nb[4] = { nb00, nb01, nb02, nb03 };
 
     // src0 is F16, src1 is F32, dst is F32
     ggml_cann_pool_alloc src0_cast_allocator;
     if (src0->type == GGML_TYPE_F16) {
         src0_cast_allocator.alloc(ctx.pool(), sizeof(float) * ggml_nelements(src0));
-        void* src0_cast_buf = src0_cast_allocator.get();
+        void * src0_cast_buf = src0_cast_allocator.get();
 
         size_t cast_nb[GGML_MAX_DIMS];
         cast_nb[0] = sizeof(float_t);
@@ -2896,9 +3324,8 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
             cast_nb[i] = cast_nb[i - 1] * src0->ne[i - 1];
         }
 
-        aclTensor* acl_src0_f16 = ggml_cann_create_tensor(src0);
-        aclTensor* acl_cast = ggml_cann_create_tensor(src0_cast_buf,
-            ACL_FLOAT, sizeof(float), src0->ne, cast_nb, 4);
+        aclTensor * acl_src0_f16 = ggml_cann_create_tensor(src0);
+        aclTensor * acl_cast = ggml_cann_create_tensor(src0_cast_buf, ACL_FLOAT, sizeof(float), src0->ne, cast_nb, 4);
         GGML_CANN_CALL_ACLNN_OP(ctx, Cast, acl_src0_f16, ACL_FLOAT, acl_cast);
         ggml_cann_release_resources(ctx, acl_cast, acl_src0_f16);
 
@@ -2909,7 +3336,7 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
 #ifdef ASCEND_310P
     ggml_tensor src0_row = *src0;
     ggml_tensor src1_row = *src1;
-    ggml_tensor dst_row = *dst;
+    ggml_tensor dst_row  = *dst;
 
     if (src0->type == GGML_TYPE_F16) {
         src0_row.type = GGML_TYPE_F32;
@@ -2941,7 +3368,7 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
     for (int64_t iid1 = 0; iid1 < ids->ne[1]; iid1++) {
         for (int64_t id = 0; id < n_ids; id++) {
             // expert index
-            int32_t i02 = *(int32_t *) (ids_host.data() + iid1*ids->nb[1] + id*ids->nb[0]);
+            int32_t i02 = *(int32_t *) (ids_host.data() + iid1 * ids->nb[1] + id * ids->nb[0]);
             GGML_ASSERT(i02 >= 0 && i02 < n_as);
 
             // If B = 1 (broadcast), always use 0; otherwise, use id.
@@ -2951,13 +3378,13 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
             int64_t i1 = id;
             int64_t i2 = i12;
 
-            void* src0_tmp_ptr = src0_original + i02*ori_src0_nb[2];
-            void* src1_tmp_ptr = src1_original + i11*nb11 + i12*nb12;
-            void* dst_tmp_ptr  = dst_original  + i1*nb1   + i2*nb2;
+            void * src0_tmp_ptr = src0_original + i02 * ori_src0_nb[2];
+            void * src1_tmp_ptr = src1_original + i11 * nb11 + i12 * nb12;
+            void * dst_tmp_ptr  = dst_original + i1 * nb1 + i2 * nb2;
 
-            src0_row.data = src0_tmp_ptr;
-            src1_row.data = src1_tmp_ptr;
-            dst_row.data = dst_tmp_ptr;
+            src0_row.data  = src0_tmp_ptr;
+            src1_row.data  = src1_tmp_ptr;
+            dst_row.data   = dst_tmp_ptr;
             dst_row.src[0] = &src0_row;
             dst_row.src[1] = &src1_row;
 
@@ -2967,23 +3394,23 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
     return;
 #endif
 
-    std::vector<aclTensor*> src0_tensor_vec;
-    std::vector<aclTensor*> src1_tensor_vec;
-    std::vector<aclTensor*> dst_tensor_vec;
+    std::vector<aclTensor *> src0_tensor_vec;
+    std::vector<aclTensor *> src1_tensor_vec;
+    std::vector<aclTensor *> dst_tensor_vec;
     for (int64_t iid1 = 0; iid1 < ids->ne[1]; iid1++) {
         for (int64_t id = 0; id < n_ids; id++) {
             // src0_row [M, D] -> weight && permute
-            int64_t src0_ne[2] = {ne01, ne00};
-            size_t src0_nb[2] = {ori_src0_nb[1], ori_src0_nb[0]};
+            int64_t src0_ne[2] = { ne01, ne00 };
+            size_t  src0_nb[2] = { ori_src0_nb[1], ori_src0_nb[0] };
             // src1_row [D, 1] -> input
-            int64_t src1_ne[2] = {ne10, 1};
-            size_t src1_nb[2] = {nb10, nb11};
+            int64_t src1_ne[2] = { ne10, 1 };
+            size_t  src1_nb[2] = { nb10, nb11 };
             // dst_row [M, 1] -> out
-            int64_t dst_ne[2] = {ne0, 1};
-            size_t dst_nb[2] = {nb0, nb1};
+            int64_t dst_ne[2]  = { ne0, 1 };
+            size_t  dst_nb[2]  = { nb0, nb1 };
 
             // expert index
-            int32_t i02 = *(int32_t *) (ids_host.data() + iid1*ids->nb[1] + id*ids->nb[0]);
+            int32_t i02 = *(int32_t *) (ids_host.data() + iid1 * ids->nb[1] + id * ids->nb[0]);
             GGML_ASSERT(i02 >= 0 && i02 < n_as);
 
             // If B = 1 (broadcast), always use 0; otherwise, use id.
@@ -2993,19 +3420,13 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
             int64_t i1 = id;
             int64_t i2 = i12;
 
-            void* src0_tmp_ptr = src0_original + i02*ori_src0_nb[2];
-            void* src1_tmp_ptr = src1_original + i11*nb11 + i12*nb12;
-            void* dst_tmp_ptr  = dst_original  + i1*nb1   + i2*nb2;
+            void * src0_tmp_ptr = src0_original + i02 * ori_src0_nb[2];
+            void * src1_tmp_ptr = src1_original + i11 * nb11 + i12 * nb12;
+            void * dst_tmp_ptr  = dst_original + i1 * nb1 + i2 * nb2;
 
-            aclTensor* acl_src0 = ggml_cann_create_tensor(src0_tmp_ptr,
-                ACL_FLOAT, sizeof(float),
-                src0_ne, src0_nb, 2);
-            aclTensor* acl_src1 = ggml_cann_create_tensor(src1_tmp_ptr,
-                ACL_FLOAT, sizeof(float),
-                src1_ne, src1_nb, 2);
-            aclTensor* acl_dst = ggml_cann_create_tensor(dst_tmp_ptr,
-                ACL_FLOAT, sizeof(float),
-                dst_ne, dst_nb, 2);
+            aclTensor * acl_src0 = ggml_cann_create_tensor(src0_tmp_ptr, ACL_FLOAT, sizeof(float), src0_ne, src0_nb, 2);
+            aclTensor * acl_src1 = ggml_cann_create_tensor(src1_tmp_ptr, ACL_FLOAT, sizeof(float), src1_ne, src1_nb, 2);
+            aclTensor * acl_dst  = ggml_cann_create_tensor(dst_tmp_ptr, ACL_FLOAT, sizeof(float), dst_ne, dst_nb, 2);
 
             src0_tensor_vec.push_back(acl_src0);
             src1_tensor_vec.push_back(acl_src1);
@@ -3017,17 +3438,30 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
     // GroupedMatmulV3 required tensor_list.size < 128
     for (size_t i = 0; i < src0_tensor_vec.size(); i += GROUP_SIZE) {
         // split and call GroupedMatmulV3
-        size_t end = std::min(i + GROUP_SIZE, src0_tensor_vec.size());
-        std::vector<aclTensor*> src0_tensor_vec_split(src0_tensor_vec.begin() + i, src0_tensor_vec.begin() + end);
-        std::vector<aclTensor*> src1_tensor_vec_split(src1_tensor_vec.begin() + i, src1_tensor_vec.begin() + end);
-        std::vector<aclTensor*> dst_tensor_vec_split(dst_tensor_vec.begin() + i, dst_tensor_vec.begin() + end);
+        size_t                   end = std::min(i + GROUP_SIZE, src0_tensor_vec.size());
+        std::vector<aclTensor *> src0_tensor_vec_split(src0_tensor_vec.begin() + i, src0_tensor_vec.begin() + end);
+        std::vector<aclTensor *> src1_tensor_vec_split(src1_tensor_vec.begin() + i, src1_tensor_vec.begin() + end);
+        std::vector<aclTensor *> dst_tensor_vec_split(dst_tensor_vec.begin() + i, dst_tensor_vec.begin() + end);
 
-        aclTensorList* src0_tensor_list = aclCreateTensorList(src0_tensor_vec_split.data(), src0_tensor_vec_split.size());
-        aclTensorList* src1_tensor_list = aclCreateTensorList(src1_tensor_vec_split.data(), src1_tensor_vec_split.size());
-        aclTensorList* dst_tensor_list = aclCreateTensorList(dst_tensor_vec_split.data(), dst_tensor_vec_split.size());
+        aclTensorList * src0_tensor_list =
+            aclCreateTensorList(src0_tensor_vec_split.data(), src0_tensor_vec_split.size());
+        aclTensorList * src1_tensor_list =
+            aclCreateTensorList(src1_tensor_vec_split.data(), src1_tensor_vec_split.size());
+        aclTensorList * dst_tensor_list = aclCreateTensorList(dst_tensor_vec_split.data(), dst_tensor_vec_split.size());
 
-        GGML_CANN_CALL_ACLNN_OP(ctx, GroupedMatmulV3, src1_tensor_list, src0_tensor_list,
-            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, -1, dst_tensor_list);
+        GGML_CANN_CALL_ACLNN_OP(ctx,
+                                GroupedMatmulV3,
+                                src1_tensor_list,
+                                src0_tensor_list,
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                nullptr,
+                                0,
+                                -1,
+                                dst_tensor_list);
 
         ggml_cann_release_resources(ctx, src0_tensor_list, src1_tensor_list, dst_tensor_list);
     }
@@ -3057,7 +3491,7 @@ static void ggml_cann_mul_mat_id_fp(ggml_backend_cann_context& ctx, ggml_tensor*
  * @note This function assumes quantized data types and is designed for
  * MoE architectures with potential sparse expert routing.
  */
-static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
+static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     // TODO: Use aclnnGroupedMatMul
     //dst   [M, K, N, 1]
     ggml_tensor * src0 = dst->src[0];  //src0	[D, M, A, 1]
@@ -3067,24 +3501,23 @@ static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context& ctx, ggml_tens
     GGML_TENSOR_BINARY_OP_LOCALS
 
     // copy index from npu to cpu
-    int64_t n_as = ne02; // A
-    int64_t n_ids = ids->ne[0]; // K
+    int64_t n_as  = ne02;        // A
+    int64_t n_ids = ids->ne[0];  // K
 
     std::vector<char> ids_host(ggml_nbytes(ids));
-    ggml_cann_async_memcpy(ctx, ids_host.data(), ids->data, ggml_nbytes(ids),
-        ACL_MEMCPY_DEVICE_TO_HOST);
+    ggml_cann_async_memcpy(ctx, ids_host.data(), ids->data, ggml_nbytes(ids), ACL_MEMCPY_DEVICE_TO_HOST);
     ACL_CHECK(aclrtSynchronizeStream(ctx.stream()));
 
     char * src0_original = (char *) src0->data;
     char * src1_original = (char *) src1->data;
-    char * dst_original  = (char *)  dst->data;
+    char * dst_original  = (char *) dst->data;
 
     ggml_tensor src0_row = *src0;
     ggml_tensor src1_row = *src1;
-    ggml_tensor dst_row = *dst;
+    ggml_tensor dst_row  = *dst;
 
     const enum ggml_type type = dst->src[0]->type;
-    float weight_elem_size;
+    float                weight_elem_size;
     if (type == GGML_TYPE_Q4_0) {
         weight_elem_size = float(sizeof(uint8_t)) / 2;
     } else if (type == GGML_TYPE_Q8_0) {
@@ -3094,18 +3527,18 @@ static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context& ctx, ggml_tens
     }
 
     // src0_row [D, M, 1, 1] weight without permute
-    src0_row.ne[2] = 1;
-    src0_row.ne[3] = 1;
-    src0_row.nb[0] = weight_elem_size;
-    src0_row.nb[1] = weight_elem_size * ne00;
-    src0_row.nb[2] = weight_elem_size * ne00;
-    src0_row.nb[3] = weight_elem_size * ne00;
+    src0_row.ne[2]       = 1;
+    src0_row.ne[3]       = 1;
+    src0_row.nb[0]       = weight_elem_size;
+    src0_row.nb[1]       = weight_elem_size * ne00;
+    src0_row.nb[2]       = weight_elem_size * ne00;
+    src0_row.nb[3]       = weight_elem_size * ne00;
     size_t weight_stride = ne00 * ne01 * weight_elem_size;
-    size_t weight_size = weight_stride * ne02 * ne03;
+    size_t weight_size   = weight_stride * ne02 * ne03;
 
     // scale [D, M, 1, 1] -> scale && permute
     size_t scale_elem_size = sizeof(uint16_t);
-    size_t scale_stride = src0->ne[1] * src0->ne[0] / QK8_0 * scale_elem_size;
+    size_t scale_stride    = src0->ne[1] * src0->ne[0] / QK8_0 * scale_elem_size;
 
     // src1_row [D, 1, 1, 1] -> input
     src1_row.ne[1] = 1;
@@ -3123,11 +3556,11 @@ static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context& ctx, ggml_tens
 
     //create weight for one row
     ggml_cann_pool_alloc weight_allocator(ctx.pool());
-    void* weight_buffer = weight_allocator.alloc(nb02);
+    void *               weight_buffer = weight_allocator.alloc(nb02);
     for (int64_t iid1 = 0; iid1 < ids->ne[1]; iid1++) {
         for (int64_t id = 0; id < n_ids; id++) {
             // expert index
-            int32_t i02 = *(int32_t *) (ids_host.data() + iid1*ids->nb[1] + id*ids->nb[0]);
+            int32_t i02 = *(int32_t *) (ids_host.data() + iid1 * ids->nb[1] + id * ids->nb[0]);
             GGML_ASSERT(i02 >= 0 && i02 < n_as);
 
             // If B = 1 (broadcast), always use 0; otherwise, use id.
@@ -3137,21 +3570,19 @@ static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context& ctx, ggml_tens
             int64_t i1 = id;
             int64_t i2 = i12;
 
-            void* src0_tmp_ptr = src0_original + i02*weight_stride;
-            void* scale_tmp_ptr = src0_original + weight_size + i02*scale_stride;
-            void* src1_tmp_ptr = src1_original + i11*nb11 + i12*nb12;
-            void* dst_tmp_ptr  = dst_original  + i1*nb1   + i2*nb2;
+            void * src0_tmp_ptr  = src0_original + i02 * weight_stride;
+            void * scale_tmp_ptr = src0_original + weight_size + i02 * scale_stride;
+            void * src1_tmp_ptr  = src1_original + i11 * nb11 + i12 * nb12;
+            void * dst_tmp_ptr   = dst_original + i1 * nb1 + i2 * nb2;
 
             // mem cpy
-            ggml_cann_async_memcpy(ctx, weight_buffer, src0_tmp_ptr, weight_stride,
-                ACL_MEMCPY_DEVICE_TO_DEVICE);
-            void* scale_buffer = (char*)weight_buffer + weight_stride;
-            ggml_cann_async_memcpy(ctx, scale_buffer, scale_tmp_ptr, scale_stride,
-                ACL_MEMCPY_DEVICE_TO_DEVICE);
+            ggml_cann_async_memcpy(ctx, weight_buffer, src0_tmp_ptr, weight_stride, ACL_MEMCPY_DEVICE_TO_DEVICE);
+            void * scale_buffer = (char *) weight_buffer + weight_stride;
+            ggml_cann_async_memcpy(ctx, scale_buffer, scale_tmp_ptr, scale_stride, ACL_MEMCPY_DEVICE_TO_DEVICE);
 
-            src0_row.data = weight_buffer;
-            src1_row.data = src1_tmp_ptr;
-            dst_row.data = dst_tmp_ptr;
+            src0_row.data  = weight_buffer;
+            src1_row.data  = src1_tmp_ptr;
+            dst_row.data   = dst_tmp_ptr;
             dst_row.src[0] = &src0_row;
             dst_row.src[1] = &src1_row;
 
@@ -3161,7 +3592,7 @@ static void ggml_cann_mul_mat_id_quant(ggml_backend_cann_context& ctx, ggml_tens
     return;
 }
 
-void ggml_cann_mul_mat_id(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
+void ggml_cann_mul_mat_id(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
     const enum ggml_type type = dst->src[0]->type;
     switch (type) {
         case GGML_TYPE_F32:
@@ -3178,52 +3609,48 @@ void ggml_cann_mul_mat_id(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     }
 }
 
-void ggml_cann_flash_attn_ext(ggml_backend_cann_context& ctx, ggml_tensor* dst){
+void ggml_cann_flash_attn_ext(ggml_backend_cann_context & ctx, ggml_tensor * dst) {
+    ggml_tensor * src0 = dst->src[0];  // q, fp32
+    ggml_tensor * src1 = dst->src[1];  // k, fp16
+    ggml_tensor * src2 = dst->src[2];  // v, fp16
+    ggml_tensor * src3 = dst->src[3];  // mask, fp16
 
-    ggml_tensor* src0 = dst->src[0]; // q, fp32
-    ggml_tensor* src1 = dst->src[1]; // k, fp16
-    ggml_tensor* src2 = dst->src[2]; // v, fp16
-    ggml_tensor* src3 = dst->src[3]; // mask, fp16
-
-    float maxBias = 0.0f;
-    float scaleValue = 1.0f;
+    float maxBias      = 0.0f;
+    float scaleValue   = 1.0f;
     float logitSoftcap = 0.0f;
-    memcpy(&scaleValue,    (float*)dst->op_params + 0, sizeof(float));
-    memcpy(&maxBias,       (float*)dst->op_params + 1, sizeof(float));
-    memcpy(&logitSoftcap,  (float*)dst->op_params + 2, sizeof(float));
+    memcpy(&scaleValue, (float *) dst->op_params + 0, sizeof(float));
+    memcpy(&maxBias, (float *) dst->op_params + 1, sizeof(float));
+    memcpy(&logitSoftcap, (float *) dst->op_params + 2, sizeof(float));
 
-    if(logitSoftcap == 0.0f){
+    if (logitSoftcap == 0.0f) {
         size_t faElemSize = sizeof(uint16_t);
-        auto   faDataType = ACL_FLOAT16; //ACL_BF16;
+        auto   faDataType = ACL_FLOAT16;  //ACL_BF16;
 
-        aclTensor* acl_src0_f16_tensor = nullptr;
-        aclTensor* acl_src1_f16_tensor = nullptr;
-        aclTensor* acl_src2_f16_tensor = nullptr;
-        aclTensor* acl_dst_f16_tensor  = nullptr;
+        aclTensor * acl_src0_f16_tensor = nullptr;
+        aclTensor * acl_src1_f16_tensor = nullptr;
+        aclTensor * acl_src2_f16_tensor = nullptr;
+        aclTensor * acl_dst_f16_tensor  = nullptr;
 
         // Step 1: cast the src0 (Query) to fp16 if needed
         ggml_cann_pool_alloc src0_f16_allocator(ctx.pool());
-        void* src0_f16_buffer = nullptr;
+        void *               src0_f16_buffer = nullptr;
 
-        if(ggml_cann_type_mapping(src0->type) != faDataType){
-            aclTensor* acl_src0_f32_tensor = ggml_cann_create_tensor(src0);
-            src0_f16_buffer = src0_f16_allocator.alloc(
-                                    ggml_nelements(src0) * faElemSize);
+        if (ggml_cann_type_mapping(src0->type) != faDataType) {
+            aclTensor * acl_src0_f32_tensor = ggml_cann_create_tensor(src0);
+            src0_f16_buffer                 = src0_f16_allocator.alloc(ggml_nelements(src0) * faElemSize);
 
-            int64_t* src0_f16_ne = src0->ne;
-            size_t   src0_f16_nb[GGML_MAX_DIMS];
+            int64_t * src0_f16_ne = src0->ne;
+            size_t    src0_f16_nb[GGML_MAX_DIMS];
             src0_f16_nb[0] = sizeof(uint16_t);
-            for(int i = 1; i < GGML_MAX_DIMS; ++i){
+            for (int i = 1; i < GGML_MAX_DIMS; ++i) {
                 src0_f16_nb[i] = src0_f16_nb[i - 1] * src0_f16_ne[i - 1];
             }
 
             acl_src0_f16_tensor = ggml_cann_create_tensor(
-                src0_f16_buffer, faDataType, faElemSize,
-                src0_f16_ne, src0_f16_nb, GGML_MAX_DIMS
-            );
+                src0_f16_buffer, faDataType, faElemSize, src0_f16_ne, src0_f16_nb, GGML_MAX_DIMS);
             aclnn_cast(ctx, acl_src0_f32_tensor, acl_src0_f16_tensor, faDataType);
             ggml_cann_release_resources(ctx, acl_src0_f32_tensor);
-        }else{
+        } else {
             acl_src0_f16_tensor = ggml_cann_create_tensor(src0);
         }
 
@@ -3234,63 +3661,57 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context& ctx, ggml_tensor* dst){
         acl_src2_f16_tensor = ggml_cann_create_tensor(src2);
 
         ggml_cann_pool_alloc out_f16_allocator(ctx.pool());
-        void* out_f16_buffer = out_f16_allocator.alloc(
-                                    ggml_nelements(dst) * faElemSize);
+        void *               out_f16_buffer = out_f16_allocator.alloc(ggml_nelements(dst) * faElemSize);
 
-        int64_t* out_f16_ne = src0->ne;
-        size_t out_f16_nb[GGML_MAX_DIMS];
+        int64_t * out_f16_ne = src0->ne;
+        size_t    out_f16_nb[GGML_MAX_DIMS];
         out_f16_nb[0] = faElemSize;
-        for(int i = 1; i < GGML_MAX_DIMS; ++i){
+        for (int i = 1; i < GGML_MAX_DIMS; ++i) {
             out_f16_nb[i] = out_f16_nb[i - 1] * out_f16_ne[i - 1];
         }
 
-        acl_dst_f16_tensor = ggml_cann_create_tensor(
-            out_f16_buffer, faDataType, faElemSize,
-            out_f16_ne, out_f16_nb, GGML_MAX_DIMS
-        );
+        acl_dst_f16_tensor =
+            ggml_cann_create_tensor(out_f16_buffer, faDataType, faElemSize, out_f16_ne, out_f16_nb, GGML_MAX_DIMS);
 
         // Step 3: create the PSEShift tensor if needed
         //         this tensor is considered as mask (f16) in the llama.cpp
 
-        aclTensor* bcast_pse_tensor = nullptr;
-        int64_t bcast_pse_ne[GGML_MAX_DIMS];
-        size_t bcast_pse_nb[GGML_MAX_DIMS];
+        aclTensor *          bcast_pse_tensor = nullptr;
+        int64_t              bcast_pse_ne[GGML_MAX_DIMS];
+        size_t               bcast_pse_nb[GGML_MAX_DIMS];
         ggml_cann_pool_alloc bcast_pse_allocator(ctx.pool());
-        void* bcast_pse_buffer = nullptr;
+        void *               bcast_pse_buffer = nullptr;
 
-        if(src3 != nullptr){
-            bcast_pse_buffer = bcast_pse_allocator.alloc(
-                            ggml_nelements(src3) * src0->ne[2] * sizeof(uint16_t));
+        if (src3 != nullptr) {
+            bcast_pse_buffer = bcast_pse_allocator.alloc(ggml_nelements(src3) * src0->ne[2] * sizeof(uint16_t));
 
-            if(src0->ne[1] > 1){
+            if (src0->ne[1] > 1) {
                 // Case 1: broadcast pse for prefill stage with multiple head
-                aclTensor* acl_mask_f16_tensor = ggml_cann_create_tensor(src3);
-                bcast_pse_ne[0] = src3->ne[0];
-                bcast_pse_ne[1] = src3->ne[1];
-                bcast_pse_ne[2] = src0->ne[2];
-                bcast_pse_ne[3] = src3->ne[3];
+                aclTensor * acl_mask_f16_tensor = ggml_cann_create_tensor(src3);
+                bcast_pse_ne[0]                 = src3->ne[0];
+                bcast_pse_ne[1]                 = src3->ne[1];
+                bcast_pse_ne[2]                 = src0->ne[2];
+                bcast_pse_ne[3]                 = src3->ne[3];
 
                 bcast_pse_nb[0] = sizeof(uint16_t);
-                for(int i = 1; i < GGML_MAX_DIMS; ++i){
+                for (int i = 1; i < GGML_MAX_DIMS; ++i) {
                     bcast_pse_nb[i] = bcast_pse_nb[i - 1] * bcast_pse_ne[i - 1];
                 }
 
                 bcast_pse_tensor = ggml_cann_create_tensor(
-                    bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t),
-                    bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
+                    bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t), bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
 
-                int64_t repeats[] = {1, src0->ne[2], 1, 1};
+                int64_t repeats[] = { 1, src0->ne[2], 1, 1 };
                 aclnn_repeat(ctx, acl_mask_f16_tensor, bcast_pse_tensor, repeats);
 
                 ggml_cann_release_resources(ctx, acl_mask_f16_tensor);
-            }else{
+            } else {
                 // Case 2: trunc the first row and broadcast pse for decode stage with multiple head
-                int64_t trunc_pse_ne[GGML_MAX_DIMS] = {src3->ne[0], src0->ne[1], src3->ne[2], src3->ne[3]};
-                size_t* trunc_pse_nb = src3->nb;
+                int64_t  trunc_pse_ne[GGML_MAX_DIMS] = { src3->ne[0], src0->ne[1], src3->ne[2], src3->ne[3] };
+                size_t * trunc_pse_nb                = src3->nb;
 
-                aclTensor* acl_mask_f16_trunc_tensor = ggml_cann_create_tensor(
-                    src3->data, ACL_FLOAT16, sizeof(uint16_t),
-                    trunc_pse_ne, trunc_pse_nb, GGML_MAX_DIMS);
+                aclTensor * acl_mask_f16_trunc_tensor = ggml_cann_create_tensor(
+                    src3->data, ACL_FLOAT16, sizeof(uint16_t), trunc_pse_ne, trunc_pse_nb, GGML_MAX_DIMS);
 
                 bcast_pse_ne[0] = src3->ne[0];
                 bcast_pse_ne[1] = src0->ne[1];
@@ -3298,38 +3719,36 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context& ctx, ggml_tensor* dst){
                 bcast_pse_ne[3] = src3->ne[3];
 
                 bcast_pse_nb[0] = sizeof(uint16_t);
-                for(int i = 1; i < GGML_MAX_DIMS; ++i){
+                for (int i = 1; i < GGML_MAX_DIMS; ++i) {
                     bcast_pse_nb[i] = bcast_pse_nb[i - 1] * bcast_pse_ne[i - 1];
                 }
 
                 bcast_pse_tensor = ggml_cann_create_tensor(
-                    bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t),
-                    bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
+                    bcast_pse_buffer, ACL_FLOAT16, sizeof(uint16_t), bcast_pse_ne, bcast_pse_nb, GGML_MAX_DIMS);
 
-                int64_t repeats[] = {1, src0->ne[2], 1, 1};
+                int64_t repeats[] = { 1, src0->ne[2], 1, 1 };
                 aclnn_repeat(ctx, acl_mask_f16_trunc_tensor, bcast_pse_tensor, repeats);
 
                 ggml_cann_release_resources(ctx, acl_mask_f16_trunc_tensor);
             }
 
             // Compute the slope if needed. Derived from ggml_cann_softmax().
-            if(maxBias != 0.0f){
+            if (maxBias != 0.0f) {
                 // alibi
-                const int64_t n_heads = src0->ne[2];
+                const int64_t        n_heads = src0->ne[2];
                 ggml_cann_pool_alloc slope_allocator(ctx.pool(), n_heads * sizeof(float));
-                void* slope_buffer = slope_allocator.get();
+                void *               slope_buffer = slope_allocator.get();
                 aclnn_get_slope(ctx, n_heads, slope_buffer, maxBias);
 
-                int64_t slope_ne[] = {1, 1, n_heads, 1};
-                size_t slope_nb[GGML_MAX_DIMS];
+                int64_t slope_ne[] = { 1, 1, n_heads, 1 };
+                size_t  slope_nb[GGML_MAX_DIMS];
                 slope_nb[0] = sizeof(float);
-                for(int i = 1;i<GGML_MAX_DIMS;i++) {
-                    slope_nb[i] = slope_nb[i-1] * slope_ne[0];
+                for (int i = 1; i < GGML_MAX_DIMS; i++) {
+                    slope_nb[i] = slope_nb[i - 1] * slope_ne[0];
                 }
 
-                aclTensor* slope_tensor = ggml_cann_create_tensor(
-                    slope_buffer, ACL_FLOAT, sizeof(float),
-                    slope_ne, slope_nb, GGML_MAX_DIMS);
+                aclTensor * slope_tensor =
+                    ggml_cann_create_tensor(slope_buffer, ACL_FLOAT, sizeof(float), slope_ne, slope_nb, GGML_MAX_DIMS);
                 GGML_CANN_CALL_ACLNN_OP(ctx, InplaceMul, bcast_pse_tensor, slope_tensor);
 
                 ggml_cann_release_resources(ctx, slope_tensor);
@@ -3337,90 +3756,104 @@ void ggml_cann_flash_attn_ext(ggml_backend_cann_context& ctx, ggml_tensor* dst){
         }
 
         // Step 4: set the inputs for FusedInferAttention.
-        int kvTensorNum = 1;
-        aclTensor* acl_q_tensor = acl_src0_f16_tensor;
-        aclTensor* acl_k_tensors[] = {acl_src1_f16_tensor};
-        aclTensor* acl_v_tensors[] = {acl_src2_f16_tensor};
-        auto acl_k_tensor_list = aclCreateTensorList(acl_k_tensors, kvTensorNum);
-        auto acl_v_tensor_list = aclCreateTensorList(acl_v_tensors, kvTensorNum);
+        int         kvTensorNum       = 1;
+        aclTensor * acl_q_tensor      = acl_src0_f16_tensor;
+        aclTensor * acl_k_tensors[]   = { acl_src1_f16_tensor };
+        aclTensor * acl_v_tensors[]   = { acl_src2_f16_tensor };
+        auto        acl_k_tensor_list = aclCreateTensorList(acl_k_tensors, kvTensorNum);
+        auto        acl_v_tensor_list = aclCreateTensorList(acl_v_tensors, kvTensorNum);
 
-        int64_t numHeads = src0->ne[2]; // N
-        int64_t numKeyValueHeads = src1->ne[2];
+        int64_t numHeads           = src0->ne[2];  // N
+        int64_t numKeyValueHeads   = src1->ne[2];
         // double  scaleValue = 1 / sqrt(src0->ne[0]); // 1/sqrt(d)
-        int64_t preTokens = 65535;
-        int64_t nextTokens = 65535;
-        char layout[5] = {'B', 'N', 'S', 'D', 0};
-        int64_t sparseMode = 0;
-        int64_t innerPrecise = (src0->ne[1] == 1) ? 0 : 2;
-        int64_t blockSize = 0;
-        int64_t antiquantMode = 0;
-        bool softmaxLseFlag = false;
-        int64_t keyAntiquantMode = 0;
+        int64_t preTokens          = 65535;
+        int64_t nextTokens         = 65535;
+        char    layout[5]          = { 'B', 'N', 'S', 'D', 0 };
+        int64_t sparseMode         = 0;
+        int64_t innerPrecise       = (src0->ne[1] == 1) ? 0 : 2;
+        int64_t blockSize          = 0;
+        int64_t antiquantMode      = 0;
+        bool    softmaxLseFlag     = false;
+        int64_t keyAntiquantMode   = 0;
         int64_t valueAntiquantMode = 0;
 
         // Step 5: launch the FusedInferAttentionScoreV2 kernel.
         // Refer to https://gitee.com/ascend/cann-ops-adv/blob/master/docs/FusedInferAttentionScoreV2.md
 
-        GGML_CANN_CALL_ACLNN_OP(ctx, FusedInferAttentionScoreV2,
-            acl_q_tensor, acl_k_tensor_list, acl_v_tensor_list, // q, k, v
-            bcast_pse_tensor, nullptr, // pse, mask
-            nullptr, nullptr, // actSeqLen, actSeqLenkv
-            nullptr, nullptr, // deqScale1, quantScale1
-            nullptr, nullptr, nullptr, // deqScale2, quantScale2, quantOffset2
-            nullptr, nullptr, // antiquantScale, antiquantOffset
-            nullptr, // blockTable
-            nullptr, nullptr, // qPadSize, kvPadSize
-            nullptr, nullptr, // kAntiquantScale, kAntiQuantOffset
-            nullptr, nullptr, // vAntiquantScale, vAntiQuantOffset
-            nullptr, nullptr, nullptr, // kSharedPrefix, vSharedPrefix, actSharedLen
-            numHeads, scaleValue, // heads, scaleValue
-            preTokens, nextTokens, // preTokens, nextTokens
-            layout, // inputLayout
-            numKeyValueHeads, // numKVHeads
-            sparseMode, innerPrecise, // sparseMode, innerPrecise
-            blockSize, antiquantMode, // blockSize, antiquantMode
-            softmaxLseFlag, // softmaxLseFlag
-            keyAntiquantMode, valueAntiquantMode, // keyAntiqMode, valueAntiqMode
-            acl_dst_f16_tensor, // attentionOut
-            nullptr // softmaxLse
+        GGML_CANN_CALL_ACLNN_OP(ctx,
+                                FusedInferAttentionScoreV2,
+                                acl_q_tensor,
+                                acl_k_tensor_list,
+                                acl_v_tensor_list,  // q, k, v
+                                bcast_pse_tensor,
+                                nullptr,            // pse, mask
+                                nullptr,
+                                nullptr,            // actSeqLen, actSeqLenkv
+                                nullptr,
+                                nullptr,            // deqScale1, quantScale1
+                                nullptr,
+                                nullptr,
+                                nullptr,  // deqScale2, quantScale2, quantOffset2
+                                nullptr,
+                                nullptr,  // antiquantScale, antiquantOffset
+                                nullptr,  // blockTable
+                                nullptr,
+                                nullptr,  // qPadSize, kvPadSize
+                                nullptr,
+                                nullptr,  // kAntiquantScale, kAntiQuantOffset
+                                nullptr,
+                                nullptr,  // vAntiquantScale, vAntiQuantOffset
+                                nullptr,
+                                nullptr,
+                                nullptr,             // kSharedPrefix, vSharedPrefix, actSharedLen
+                                numHeads,
+                                scaleValue,          // heads, scaleValue
+                                preTokens,
+                                nextTokens,          // preTokens, nextTokens
+                                layout,              // inputLayout
+                                numKeyValueHeads,    // numKVHeads
+                                sparseMode,
+                                innerPrecise,        // sparseMode, innerPrecise
+                                blockSize,
+                                antiquantMode,       // blockSize, antiquantMode
+                                softmaxLseFlag,      // softmaxLseFlag
+                                keyAntiquantMode,
+                                valueAntiquantMode,  // keyAntiqMode, valueAntiqMode
+                                acl_dst_f16_tensor,  // attentionOut
+                                nullptr              // softmaxLse
         );
 
         // Step 6: post-processing, permute and cast to f32
 
-        int64_t new_dim[] = {0, 2, 1, 3};
-        aclTensor* acl_dst_tensor = ggml_cann_create_tensor(dst);
+        int64_t     new_dim[]      = { 0, 2, 1, 3 };
+        aclTensor * acl_dst_tensor = ggml_cann_create_tensor(dst);
 
-        if(ggml_cann_type_mapping(dst->type) != faDataType){
+        if (ggml_cann_type_mapping(dst->type) != faDataType) {
             ggml_cann_pool_alloc perm_out_f16_allocator(ctx.pool());
             perm_out_f16_allocator.alloc(ggml_nelements(dst) * faElemSize);
-            void* perm_out_f16_buffer = perm_out_f16_allocator.get();
+            void * perm_out_f16_buffer = perm_out_f16_allocator.get();
 
-            int64_t* perm_out_f16_ne = dst->ne;
-            size_t  perm_out_f16_nb[GGML_MAX_DIMS];
+            int64_t * perm_out_f16_ne = dst->ne;
+            size_t    perm_out_f16_nb[GGML_MAX_DIMS];
             perm_out_f16_nb[0] = faElemSize;
-            for(int i = 1; i < GGML_MAX_DIMS; ++i){
+            for (int i = 1; i < GGML_MAX_DIMS; ++i) {
                 perm_out_f16_nb[i] = perm_out_f16_nb[i - 1] * perm_out_f16_ne[i - 1];
             }
-            aclTensor* acl_perm_out_f16_tensor = ggml_cann_create_tensor(
-                perm_out_f16_buffer, faDataType, faElemSize,
-                perm_out_f16_ne, perm_out_f16_nb, GGML_MAX_DIMS);
+            aclTensor * acl_perm_out_f16_tensor = ggml_cann_create_tensor(
+                perm_out_f16_buffer, faDataType, faElemSize, perm_out_f16_ne, perm_out_f16_nb, GGML_MAX_DIMS);
             aclnn_permute(ctx, acl_dst_f16_tensor, acl_perm_out_f16_tensor, new_dim, GGML_MAX_DIMS);
-            aclnn_cast(ctx,
-                acl_perm_out_f16_tensor, acl_dst_tensor, ggml_cann_type_mapping(dst->type));
+            aclnn_cast(ctx, acl_perm_out_f16_tensor, acl_dst_tensor, ggml_cann_type_mapping(dst->type));
             ggml_cann_release_resources(ctx, acl_perm_out_f16_tensor);
-        }else{
+        } else {
             // only need to permute
             aclnn_permute(ctx, acl_dst_f16_tensor, acl_dst_tensor, new_dim, GGML_MAX_DIMS);
         }
-        ggml_cann_release_resources(ctx, acl_src0_f16_tensor,
-                                         acl_src1_f16_tensor,
-                                         acl_src2_f16_tensor,
-                                         acl_dst_f16_tensor,
-                                         acl_dst_tensor);
-        if(src3 != nullptr){
+        ggml_cann_release_resources(
+            ctx, acl_src0_f16_tensor, acl_src1_f16_tensor, acl_src2_f16_tensor, acl_dst_f16_tensor, acl_dst_tensor);
+        if (src3 != nullptr) {
             ggml_cann_release_resources(ctx, bcast_pse_tensor);
         }
-    }else{
+    } else {
         GGML_ABORT("Function is not implemented.");
     }
 }

--- a/ggml/src/ggml-cann/aclnn_ops.h
+++ b/ggml/src/ggml-cann/aclnn_ops.h
@@ -187,6 +187,9 @@ void ggml_cann_argsort(ggml_backend_cann_context& ctx, ggml_tensor* dst);
  */
 void ggml_cann_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst);
 
+
+void ggml_cann_out_prod(ggml_backend_cann_context & ctx, ggml_tensor * dst);
+
 /**
  * @brief  Computes the Group Normalization for a ggml tensor using the CANN
  *         backend.

--- a/ggml/src/ggml-cann/ggml-cann.cpp
+++ b/ggml/src/ggml-cann/ggml-cann.cpp
@@ -1771,6 +1771,10 @@ static bool ggml_cann_compute_forward(ggml_backend_cann_context& ctx,
                     return false;
             }
             break;
+        // ===== OUT_PROD =====
+        case GGML_OP_OUT_PROD:
+            ggml_cann_out_prod(ctx, dst);
+            return true;
         case GGML_OP_NORM:
             ggml_cann_norm(ctx, dst);
             break;
@@ -2403,6 +2407,26 @@ static bool ggml_backend_cann_supports_op(ggml_backend_dev_t dev,
                     return false;
             }
         }
+
+        // ===== OUT_PROD =====
+        case GGML_OP_OUT_PROD: {
+            switch (op->src[0]->type) {
+                case GGML_TYPE_F32:
+                // case GGML_TYPE_F16:
+                case GGML_TYPE_Q8_0:
+                case GGML_TYPE_Q4_0:
+                case GGML_TYPE_Q4_1: 
+                case GGML_TYPE_Q4_K:
+                case GGML_TYPE_MXFP4:
+                case GGML_TYPE_IQ2_XXS:
+                    return op->src[1]->type == GGML_TYPE_F32 && op->type == GGML_TYPE_F32;
+                    // return (op->src[1]->type == GGML_TYPE_F32 || op->src[1]->type == GGML_TYPE_F16) && 
+                    //        (op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16);
+                default:
+                    return false;
+            }
+        }
+
         case GGML_OP_ROPE: {
             // TODO: with ops-test v == 1
             float ext_factor = 0.0f;


### PR DESCRIPTION
#### Description

Implement  `GGML_OP_OUT_PROD` for CANN backend in llama.cpp.

####  `OUT_PROD` Operator

​Shapes:
​	​`A = src0`: Shape `[I, K, A_n2, A_n3]`
​	​`B = src1`: Shape `[J, K, B_n2, B_n3]`
​	​`C = dst` : Shape `[I, J, C_n2, C_n3]`

​For each batch `(i2, i3)`:

<img width="808" height="102" alt="image" src="https://github.com/user-attachments/assets/8998d361-64bc-47ec-8eba-9d0ac7f68905" />

​	Parameters: `K = max(A.ne[1], B.ne[1])`

​	Implement the cases of input tensor type:
​	- `src0->type == fp32, src1->type == fp32`
​	- `src0->type in {q8_0, q4_0, q4_1, q4_k, mxfp4, iq2_xxs}, src1->type == fp32`
​	Skip `fp16` cases as they are not supported by CPU.

#### Design Details
- Operator Registration and Dispatch
   - Register GGML_OP_OUT_PROD in ggml_backend_cann_supports_op: Validate data types and dimensions (F32 + supported quantized types / batch alignment).
   - Dispatch the operator implementation ggml_cann_out_prod(ctx, dst); within the switch (dst->op) block in ggml_cann_compute_forward.

- `fp32`
  - Validate the dimensions of A, B, and C, specifically checking for batch alignment and K-dimension broadcasting conditions.

  - Treat each `(i2, i3)` batch block as an independent matrix multiplication. Map A (`[I, K]`), B (`[K, J]`), and C (`[I, J]`) to the CANN `BatchMatMul` interface.

  - Handle batch dimensions by iterating through the batches.

  - Implement K-dimension broadcasting by setting the stride to 0.

- `q8_0` and `q4_0`
  - The memory layout is different from the CPU version (see `need_transform` in `ggml-cann.cpp`)
  - Use `ggml_backend_tensor_get` to get the data back to the host, and the layout will change back to CPU version automatically.
  - Copy the dequantized data back to CANN, then reuse the computation logic of `fp32`.
  - Note: `ggml_cann_get_rows` in `aclnn_ops.cpp` implements `q8_0` processing. Unpack the `q8_0` according to this reference function is also fine, but it cannot apply on `q4_0` due to some bugs.

- Other quantized types
  - Their memory layouts are the same as the CPU version.
  - Directly copy the memory block back to the host, and dequantize on CPU.
  - Copy the dequantized data back to CANN, then reuse the computation logic of `fp32`

#### Test

- Compilation：

```markdown
cmake -B build -DGGML_CANN=on -DCMAKE_BUILD_TYPE=release
cmake --build build --config release -j
```

- Running：

```markdown
./build/bin/test-backend-ops test -b CANN0 -o OUT_PROD
```

- Results：

​	OUT_PROD passed all `CANN` backend test cases with support.

<img width="1404" height="909" alt="image" src="https://github.com/user-attachments/assets/44fed546-f07d-40cc-b0e6-0b68c8c6a096" />


<img width="1211" height="568" alt="image" src="https://github.com/user-attachments/assets/b37d818a-0839-40db-be0d-df9ee24d5a1a" />

#### Notes

We didn't implement `fp16` as they are not implemented in CPU version and cannot be tested. `fp16` is not a quantized type, so simply cast the type into `fp32` is OK (refer to `ggml_cann_get_rows` in `aclnn_ops.cpp`). In addition, CANN devices natively support `fp16`.