### PR TITLE
CANN: llama-parallel 精度问题Bug修复

### DIFF
--- a/ggml/src/ggml-cann/aclnn_ops.cpp
+++ b/ggml/src/ggml-cann/aclnn_ops.cpp
@@ -516,17 +516,69 @@ void ggml_cann_acc(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
  * @param dim An array of dimension indices.
  * @param dim_size The number of dimensions.
  */
-static void aclnn_reduce_sum(ggml_backend_cann_context& ctx, ggml_tensor* dst,
+static void aclnn_reduce_sum(ggml_backend_cann_context& ctx,
+                             ggml_tensor* dst,
                              int64_t* dim, size_t dim_size) {
     GGML_ASSERT(dst->ne[0] == 1);
     ggml_tensor* src = dst->src[0];
     aclTensor* acl_src = ggml_cann_create_tensor(src);
-    aclTensor* acl_dst = ggml_cann_create_tensor(dst);
     aclIntArray* reduce_dims = aclCreateIntArray(dim, dim_size);
 
-    GGML_CANN_CALL_ACLNN_OP(ctx, ReduceSum, acl_src, reduce_dims, true,
-                      ggml_cann_type_mapping(dst->type), acl_dst);
-    ggml_cann_release_resources(ctx, acl_src, acl_dst, reduce_dims);
+    bool use_fp32_accum = (dst->type != GGML_TYPE_F32);
+
+    aclTensor* acl_dst = nullptr;
+    aclTensor* acl_tmp = nullptr;
+
+    if (!use_fp32_accum) {
+        // write result directly into dst (original path)
+        acl_dst = ggml_cann_create_tensor(dst);
+        GGML_CANN_CALL_ACLNN_OP(ctx, ReduceSum,
+                                acl_src, reduce_dims, true,
+                                ggml_cann_type_mapping(dst->type), acl_dst);
+        ggml_cann_release_resources(ctx, acl_src, acl_dst, reduce_dims);
+    } else {
+        // accumulate in FP32 first, then cast to dst type
+        size_t nelems = ggml_nelements(dst);
+        size_t tmp_bytes = nelems * sizeof(float);
+
+        ggml_cann_pool_alloc tmp_buf(ctx.pool(), tmp_bytes);
+        void* tmp_data = tmp_buf.get();
+
+        // build temporary FP32 tensor
+        int64_t tmp_ne[GGML_MAX_DIMS];
+        size_t  tmp_nb[GGML_MAX_DIMS];
+
+        for (int i = 0; i < GGML_MAX_DIMS; ++i) {
+            tmp_ne[i] = dst->ne[i];
+        }
+        tmp_nb[0] = sizeof(float);
+        for (int i = 1; i < GGML_MAX_DIMS; ++i) {
+            tmp_nb[i] = tmp_nb[i - 1] * tmp_ne[i - 1];
+        }
+
+        acl_tmp = ggml_cann_create_tensor(tmp_data,
+                                          ACL_FLOAT,
+                                          sizeof(float),
+                                          tmp_ne, tmp_nb,
+                                          GGML_MAX_DIMS,
+                                          ACL_FORMAT_ND);
+
+        acl_dst = ggml_cann_create_tensor(dst);
+
+        // ReduceSum → FP32 temp
+        GGML_CANN_CALL_ACLNN_OP(ctx, ReduceSum,
+                                acl_src, reduce_dims, true,
+                                aclDataType::ACL_FLOAT,
+                                acl_tmp);
+
+        // cast FP32 → dst dtype
+        GGML_CANN_CALL_ACLNN_OP(ctx, Cast,
+                                acl_tmp,
+                                ggml_cann_type_mapping(dst->type),
+                                acl_dst);
+
+        ggml_cann_release_resources(ctx, acl_src, acl_dst, acl_tmp, reduce_dims);
+    }
 }
 
 void ggml_cann_sum_rows(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
@@ -956,38 +1008,34 @@ void ggml_cann_rms_norm(ggml_backend_cann_context& ctx, ggml_tensor* dst) {
     float eps;
     memcpy(&eps, dst->op_params, sizeof(float));
 
-    // build gamma, one...
-    size_t acl_gamma_nb[GGML_MAX_DIMS];
-    acl_gamma_nb[0] = sizeof(float);
-    for (int i = 1; i < GGML_MAX_DIMS; i++) {
-        acl_gamma_nb[i] = acl_gamma_nb[i - 1] * src->ne[i - 1];
-    }
-    aclTensor* acl_gamma = get_f32_cache_acl_tensor(
-        ctx,
-        &ctx.f32_one_cache,
-        ctx.f32_one_cache_element,
-        src->ne,
-        acl_gamma_nb,
-        1,        // dims
-        1.0f      // value
-    );
+    // gamma: same dtype as dst, filled with 1.0
+    const size_t gamma_elem_size = ggml_type_size(dst->type);
+    const aclDataType gamma_acl_dtype = ggml_cann_type_mapping(dst->type);
 
-    // build rstd, zero...
+    int64_t gamma_ne[1] = { src->ne[0] };
+    size_t  gamma_nb[1] = { gamma_elem_size };
+
+    ggml_cann_pool_alloc gamma_allocator(ctx.pool(), gamma_ne[0] * gamma_elem_size);
+    void* gamma_buffer = gamma_allocator.get();
+
+    aclTensor* acl_gamma = ggml_cann_create_tensor(
+        gamma_buffer, gamma_acl_dtype, gamma_elem_size,
+        gamma_ne, gamma_nb, 1);
+
+    aclnn_fill_scalar(ctx, 1.0f, acl_gamma);
+
+    // rstd: keep FP32 as in original implementation
     size_t acl_rstd_nb[GGML_MAX_DIMS];
     acl_rstd_nb[0] = sizeof(float);
     for (int i = 1; i < GGML_MAX_DIMS; i++) {
         acl_rstd_nb[i] = acl_rstd_nb[i - 1] * src->ne[i - 1];
     }
-    aclTensor* acl_rstd = get_f32_cache_acl_tensor(
-        ctx,
-        &ctx.f32_zero_cache,
-        ctx.f32_zero_cache_element,
-        src->ne,
-        acl_rstd_nb,
-        GGML_MAX_DIMS,
-        0.0f      // value
-    );
 
+    aclTensor* acl_rstd = get_f32_cache_acl_tensor(
+        ctx, &ctx.f32_zero_cache, ctx.f32_zero_cache_element,
+        src->ne, acl_rstd_nb, GGML_MAX_DIMS, 0.0f);
+
+    // RMSNorm
     GGML_CANN_CALL_ACLNN_OP(ctx, RmsNorm, acl_src, acl_gamma, eps, acl_dst, acl_rstd);
     ggml_cann_release_resources(ctx, acl_src, acl_dst, acl_gamma, acl_rstd);
 }


### PR DESCRIPTION
## **描述 (Description)**

本次 PR 主要对 CANN 后端进行两处小而安全的精度鲁棒性增强修复，目标是提升 `llama-parallel` 在多并发场景下的稳定性。

相关问题：[issue "llama-parallel 精度问题Bug修复"](https://github.com/noemotiovon/llama.cpp/issues/1#issuecomment-3290263551)


**主要改动：**

1. **在 `aclnn_reduce_sum` 中引入 FP32 中间 buffer**
    - 对于半精度输出场景，先将 ReduceSum 的结果计算到 FP32 临时 buffer，再 Cast 回目标类型。
    - 这一改动可以减少大规模并行归约时的数值抖动。
2. **RMSNorm：gamma 权重类型对齐到 dst**
    - 旧代码强制 gamma 为 FP32，这会在 FP16/BF16 推理模式下产生隐式类型转换，可能影响精度或产生不必要的 warning。
    - 新逻辑根据 `dst->type` 生成相同 dtype 的 gamma，并填充值为 1.0，行为更合理且与新版社区代码一致。

这两处改动均不改变算子的数学定义，只提升数值稳定性与混合精度场景兼容性。

---

## **测试 (Testing)**

使用 Qwen3-0.6B Q4_0 模型在 Ascend910B2 上运行以下脚本进行验证：

```
./bin/llama-parallel -m Qwen3-0.6B-Q4_0.gguf -np 8 -ns 128 --top-k 1 --junk 10 -c 16384 -ngl 99

```

测试中 8 个客户端并行执行 128 次请求，模型生成结果稳定、无异常输出，整体回答逻辑清晰、风格一致，符合预期。

部分运行结果见附件日志：

（来自 PR 讨论区的完整日志，同步提交）

> 可参考示例输出：模型在不同 seq 上输出内容风格一致、语义合理，例如关于 “meaning of life”、“how to get a job at Google” 等 prompt 的多次回答均保持一致性与可读性（）。
> 

此外：

- 修改前后对比，无异常数值、无 NAN/INF、无越界。
- 进一步在 **CPU / GPU 后端** 运行相同脚本，行为模式高度一致，说明 CANN 后端在本次修复后与其他后端达到相同的稳定性。
- 对于相同 prompt，response 并不能完全字节级一致（特别是序列后段出现个别 token 差异），这是 **由 `-junk` 参数特性导致的**——模型收到可变数量的“干扰 token”后，本身就会产生轻微多样性。此现象在CPU / GPU 后端同样发生，属于预期行为。
- 当 `-junk 0` 时，所有并发请求达到完全一致的 deterministic 输出。

因此可以确认，修改后的行为正确且鲁棒性优于修改前

---

## **备注 (Notes)**

- 在修复之前，本地测试的基础版本其实已经没有明显精度问题，模型输出均合理，多个并发客户端对同一 prompt 的回答也非常一致。社区中出现的一些“精度问题反馈”，根据讨论和对比测试来看，很多情况更可能与模型本身的量化方式、训练细节、或启发式采样参数有关，而非由推理引擎（CANN 后端）直接导致。
- 本次 PR 的目标不是修复“致命错误”，而是**进一步增强并行精度鲁棒性**，避免大 batch / 大维度归约场景下的潜在抖动，并使 RMSNorm 的权重类型定义更加严谨。
- 这两处改动均是局部的、小范围的，不涉及大规模结构性重写，易于维护，也与社区代码方向一致。
- 预计不会影响性能，也不会对已有模型产生兼容性问题。